### PR TITLE
Andya001

### DIFF
--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
@@ -6,12 +6,18 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.renderer.category.BarRenderer;
+import org.jfree.chart.renderer.category.CategoryItemRenderer;
+import org.jfree.chart.renderer.category.StandardBarPainter;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisElement;
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
+import ch.ethz.idsc.amodeus.analysis.plot.ChartTheme;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.report.AnalysisReport;
 import ch.ethz.idsc.amodeus.analysis.report.HtmlReport;
 import ch.ethz.idsc.amodeus.analysis.report.HtmlReportElement;
@@ -69,6 +75,8 @@ public class Analysis {
     private final int size;
     private final AnalysisSummary analysisSummary;
     private final HtmlReport htmlReport;
+    private final ColorScheme colorScheme;
+    private final ChartTheme chartTheme;
 
     /** Constructor of the Analysis Class can be called with any combination of null and the respective parameter.
      * 
@@ -97,6 +105,15 @@ public class Analysis {
         if (Objects.isNull(network)) {
             network = NetworkLoader.loadNetwork(configFile);
         }
+        
+        // load colorScheme & theme
+        colorScheme = ColorScheme.valueOf(scenOptions.getColorScheme());
+        chartTheme = ChartTheme.valueOf(scenOptions.getChartTheme());
+        
+        ChartFactory.setChartTheme(chartTheme.getChartTheme(false));
+        
+        BarRenderer.setDefaultBarPainter(new StandardBarPainter());
+        BarRenderer.setDefaultShadowsVisible(false);
 
         outputDirectory.mkdir();
         dataDirectory = new File(outputDirectory, DATAFOLDERNAME);
@@ -169,7 +186,7 @@ public class Analysis {
         analysisElements.forEach(AnalysisElement::consolidate);
 
         for (AnalysisExport analysisExport : analysisExports)
-            analysisExport.summaryTarget(analysisSummary, dataDirectory);
+            analysisExport.summaryTarget(analysisSummary, dataDirectory, colorScheme);
 
         // Generate the Reports
         analysisReports.forEach(analysisReport -> analysisReport.generate(analysisSummary));

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.renderer.category.BarRenderer;
-import org.jfree.chart.renderer.category.CategoryItemRenderer;
 import org.jfree.chart.renderer.category.StandardBarPainter;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.Config;
@@ -111,7 +110,6 @@ public class Analysis {
         chartTheme = ChartTheme.valueOf(scenOptions.getChartTheme());
         
         ChartFactory.setChartTheme(chartTheme.getChartTheme(false));
-        
         BarRenderer.setDefaultBarPainter(new StandardBarPainter());
         BarRenderer.setDefaultShadowsVisible(false);
 

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/BinnedWaitingTimesImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/BinnedWaitingTimesImage.java
@@ -5,13 +5,14 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.WaitingTimesElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.TimeChart;
 
 public class BinnedWaitingTimesImage implements AnalysisExport {
     public static final String FILENAME = "binnedWaitingTimes";
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         WaitingTimesElement wt = analysisSummary.getWaitingTimes();
 
         String xAxisLabel = "Time";
@@ -32,7 +33,8 @@ public class BinnedWaitingTimesImage implements AnalysisExport {
                     yAxisLabel, //
                     wt.time, //
                     wt.waitTimePlotValues, //
-                    wt.maximumWaitTime / scalingFactor);
+                    wt.maximumWaitTime / scalingFactor,
+                    colorScheme);
         } catch (Exception e) {
             System.err.println("Binned Waiting Times Plot was unsucessfull!");
             e.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/DistanceDistributionOverDayImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/DistanceDistributionOverDayImage.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.StackedTimeChart;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.alg.Transpose;
@@ -14,7 +15,7 @@ public class DistanceDistributionOverDayImage implements AnalysisExport {
     public static final String FILENAME = "distanceDistribution";
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         DistanceElement de = analysisSummary.getDistanceElement();
         String[] diagramLables = Arrays.copyOf(StaticHelper.descriptions(), 3);
         Double[] scale = new Double[diagramLables.length];
@@ -32,7 +33,8 @@ public class DistanceDistributionOverDayImage implements AnalysisExport {
                     diagramLables, //
                     "Distance [km]", //
                     de.time, //
-                    distances);
+                    distances, //
+                    colorScheme);
         } catch (Exception e) {
             System.err.println("modularDistanceDistribution plot was unsucessfull");
             e.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/DistancesOverDayTable.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/DistancesOverDayTable.java
@@ -5,11 +5,12 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.tensor.io.TableBuilder;
 
 public class DistancesOverDayTable implements AnalysisExport {
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         DistanceElement de = analysisSummary.getDistanceElement();
 
         TableBuilder tableBuilder = new TableBuilder();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/DistancesRatiosTable.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/DistancesRatiosTable.java
@@ -5,11 +5,12 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.tensor.io.TableBuilder;
 
 public class DistancesRatiosTable implements AnalysisExport {
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         DistanceElement de = analysisSummary.getDistanceElement();
 
         TableBuilder tableBuilder = new TableBuilder();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/OccupancyDistanceRatiosImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/OccupancyDistanceRatiosImage.java
@@ -5,6 +5,7 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.TimeChart;
 
 public class OccupancyDistanceRatiosImage implements AnalysisExport {
@@ -12,7 +13,7 @@ public class OccupancyDistanceRatiosImage implements AnalysisExport {
     private static final String[] RATIOS_LABELS = new String[] { "occupancy ratio", "distance ratio" };
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         DistanceElement de = analysisSummary.getDistanceElement();
         double[] scaleratios = new double[] { 1.0, 1.0 };
         try {
@@ -28,7 +29,8 @@ public class OccupancyDistanceRatiosImage implements AnalysisExport {
                     "occupancy / distance ratio", //
                     de.time, //
                     de.ratios, //
-                    1.0);
+                    1.0,
+                    colorScheme);
         } catch (Exception e1) {
             System.err.println("The Modular Ratios Plot was not sucessful!!");
             e1.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/RequestsPerWaitingTimeImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/RequestsPerWaitingTimeImage.java
@@ -5,6 +5,7 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.WaitingTimesElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.DiagramSettings;
 import ch.ethz.idsc.amodeus.analysis.plot.HistogramPlot;
 import ch.ethz.idsc.tensor.RealScalar;
@@ -18,7 +19,7 @@ public class RequestsPerWaitingTimeImage implements AnalysisExport {
     public static final String FILENAME = "requestsPerWaitTime";
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         WaitingTimesElement wt = analysisSummary.getWaitingTimes();
 
         int waitBinNumber = 30;
@@ -36,14 +37,15 @@ public class RequestsPerWaitingTimeImage implements AnalysisExport {
 
         try {
             HistogramPlot.of( //
-                    waitBinCounter, //
+                    waitBinCounter.multiply(RealScalar.of(100)), //
                     relativeDirectory, //
                     FILENAME, //
                     "Number of Requests per Wait Time", //
                     waitBinSize.number().doubleValue(), //
                     "% of requests", //
                     "Waiting Times [s]", //
-                    DiagramSettings.WIDTH, DiagramSettings.HEIGHT);
+                    DiagramSettings.WIDTH, DiagramSettings.HEIGHT,
+                    colorScheme);
         } catch (Exception e) {
             System.err.println("Plot of the Wait Times per Requests Failed");
             e.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/ScenarioParametersExport.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/ScenarioParametersExport.java
@@ -4,11 +4,12 @@ package ch.ethz.idsc.amodeus.analysis;
 import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.tensor.io.Export;
 
 public class ScenarioParametersExport implements AnalysisExport {
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         ScenarioParameters scenarioParameters = analysisSummary.getScenarioParameters();
         try {
             Export.object(new File(relativeDirectory, "scenarioParameters.obj"), scenarioParameters);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/StackedDistanceChartImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/StackedDistanceChartImage.java
@@ -5,13 +5,14 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.CompositionStack;
 
 public class StackedDistanceChartImage implements AnalysisExport {
     public static final String FILENAME = "stackedDistance";
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         DistanceElement de = analysisSummary.getDistanceElement();
         String[] labels = { "With Customer", "Pickup", "Rebalancing" };
         double[] values = new double[] { //
@@ -24,7 +25,8 @@ public class StackedDistanceChartImage implements AnalysisExport {
                     FILENAME, //
                     "Total Distance Distribution", //
                     values, //
-                    labels);
+                    labels, //
+                    colorScheme);
         } catch (Exception e) {
             System.err.println("The Stacked Distance Plot was not successfull");
             e.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/StatusDistributionImage.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/StatusDistributionImage.java
@@ -6,13 +6,14 @@ import java.util.Arrays;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.StatusDistributionElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.amodeus.analysis.plot.StackedTimeChart;
 
 public class StatusDistributionImage implements AnalysisExport {
     public static final String FILENAME = "statusDistribution";
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         String[] statusLabels = StaticHelper.descriptions();
         StatusDistributionElement st = analysisSummary.getStatusDistribution();
 
@@ -29,7 +30,8 @@ public class StatusDistributionImage implements AnalysisExport {
                     statusLabels, //
                     "RoboTaxis", //
                     st.time, //
-                    st.statusTensor);
+                    st.statusTensor, //
+                    colorScheme);
         } catch (Exception e1) {
             System.err.println("The Modular status dist with Tensor was not carried out!!");
             e1.printStackTrace();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/StatusDistributionTable.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/StatusDistributionTable.java
@@ -5,12 +5,13 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.StatusDistributionElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.tensor.io.TableBuilder;
 
 public class StatusDistributionTable implements AnalysisExport {
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         StatusDistributionElement sd = analysisSummary.getStatusDistribution();
 
         TableBuilder tableBuilder = new TableBuilder();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/WaitingTimesTable.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/WaitingTimesTable.java
@@ -5,12 +5,13 @@ import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.analysis.element.WaitingTimesElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 import ch.ethz.idsc.tensor.io.TableBuilder;
 
 public class WaitingTimesTable implements AnalysisExport {
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         WaitingTimesElement wt = analysisSummary.getWaitingTimes();
 
         TableBuilder tableBuilder = new TableBuilder();

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/element/AnalysisExport.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/element/AnalysisExport.java
@@ -4,9 +4,10 @@ package ch.ethz.idsc.amodeus.analysis.element;
 import java.io.File;
 
 import ch.ethz.idsc.amodeus.analysis.AnalysisSummary;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 
 public interface AnalysisExport {
     /** @param analysisSummary
      * @param relativeDirectory for instance "output/001/data" */
-    void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory);
+    void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme);
 }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/element/DistanceElement.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/element/DistanceElement.java
@@ -70,7 +70,9 @@ public class DistanceElement implements AnalysisElement {
 
     @Override
     public void consolidate() {
-        list.forEach(VehicleStatistic::consolidate);
+        // no need to to consolidate again, if vehicles still driving only small fraction of distance lost
+        // if vehicles are already in stay, then no difference. if consolidate is run here it will 
+        // result in a runtime erro (indexoutofbounds)
         // ---
         Tensor distTotal = list.stream().map(vs -> vs.distanceTotal).reduce(Tensor::add).get().multiply(km2m);
         Tensor distWtCst = list.stream().map(vs -> vs.distanceWithCustomer).reduce(Tensor::add).get().multiply(km2m);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/element/DistanceElement.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/element/DistanceElement.java
@@ -70,10 +70,8 @@ public class DistanceElement implements AnalysisElement {
 
     @Override
     public void consolidate() {
-        // no need to to consolidate again, if vehicles still driving only small fraction of distance lost
-        // if vehicles are already in stay, then no difference. if consolidate is run here it will 
-        // result in a runtime erro (indexoutofbounds)
-        // ---
+        list.forEach(VehicleStatistic::consolidate);
+
         Tensor distTotal = list.stream().map(vs -> vs.distanceTotal).reduce(Tensor::add).get().multiply(km2m);
         Tensor distWtCst = list.stream().map(vs -> vs.distanceWithCustomer).reduce(Tensor::add).get().multiply(km2m);
         Tensor distPicku = list.stream().map(vs -> vs.distancePickup).reduce(Tensor::add).get().multiply(km2m);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/element/VehicleStatistic.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/element/VehicleStatistic.java
@@ -57,21 +57,23 @@ import ch.ethz.idsc.tensor.alg.Array;
             int count = 0;
             for (VehicleContainer vehicleContainer : list) {
                 final int index = offset + count;
-                switch (vehicleContainer.roboTaxiStatus) {
-                case DRIVEWITHCUSTOMER:
-                    distanceWithCustomer.set(contrib, index);
-                    distanceTotal.set(contrib, index); // applies to all three
-                    break;
-                case DRIVETOCUSTOMER:
-                    distancePickup.set(contrib, index);
-                    distanceTotal.set(contrib, index); // applies to all three
-                    break;
-                case REBALANCEDRIVE:
-                    distanceRebalance.set(contrib, index);
-                    distanceTotal.set(contrib, index); // applies to all three
-                    break;
-                default:
-                    break;
+                if (index < distanceTotal.length()) {
+                    switch (vehicleContainer.roboTaxiStatus) {
+                    case DRIVEWITHCUSTOMER:
+                        distanceWithCustomer.set(contrib, index);
+                        distanceTotal.set(contrib, index); // applies to all three
+                        break;
+                    case DRIVETOCUSTOMER:
+                        distancePickup.set(contrib, index);
+                        distanceTotal.set(contrib, index); // applies to all three
+                        break;
+                    case REBALANCEDRIVE:
+                        distanceRebalance.set(contrib, index);
+                        distanceTotal.set(contrib, index); // applies to all three
+                        break;
+                    default:
+                        break;
+                    }
                 }
                 ++count;
             }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ChartTheme.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ChartTheme.java
@@ -1,0 +1,51 @@
+package ch.ethz.idsc.amodeus.analysis.plot;
+
+import java.awt.Color;
+import java.awt.Font;
+
+import org.jfree.chart.StandardChartTheme;
+import org.jfree.chart.plot.DefaultDrawingSupplier;
+import org.jfree.chart.plot.PieLabelLinkStyle;
+import org.jfree.chart.renderer.category.BarRenderer3D;
+import org.jfree.chart.renderer.category.StandardBarPainter;
+import org.jfree.chart.renderer.xy.StandardXYBarPainter;
+import org.jfree.ui.RectangleInsets;
+
+public enum ChartTheme {
+    STANDARD {
+        @Override
+        public StandardChartTheme getChartTheme(boolean shadow) {
+            StandardChartTheme theme = new StandardChartTheme("amodeus");
+            theme.setExtraLargeFont(new Font("Dialog", Font.BOLD, 24));
+            theme.setLargeFont(new Font("Dialog", Font.PLAIN, 18));
+            theme.setRegularFont(new Font("Dialog", Font.PLAIN, 14));
+            theme.setSmallFont(new Font("Dialog", Font.PLAIN, 10));
+            theme.setTitlePaint(Color.BLACK);
+            theme.setSubtitlePaint(Color.BLACK);
+            theme.setLegendBackgroundPaint(Color.WHITE);
+            theme.setLegendItemPaint(Color.BLACK);
+            theme.setChartBackgroundPaint(Color.WHITE);
+            theme.setDrawingSupplier(new DefaultDrawingSupplier());
+            theme.setPlotBackgroundPaint(Color.WHITE);
+            theme.setPlotOutlinePaint(Color.BLACK);
+            theme.setLabelLinkStyle(PieLabelLinkStyle.STANDARD);
+            theme.setAxisOffset(new RectangleInsets(4, 4, 4, 4));
+            theme.setDomainGridlinePaint(Color.WHITE);
+            theme.setRangeGridlinePaint(Color.WHITE);
+            theme.setBaselinePaint(Color.BLACK);
+            theme.setCrosshairPaint(Color.BLACK);
+            theme.setAxisLabelPaint(Color.DARK_GRAY);
+            theme.setTickLabelPaint(Color.DARK_GRAY);
+            theme.setBarPainter(new StandardBarPainter());
+            theme.setXYBarPainter(new StandardXYBarPainter());
+            theme.setShadowVisible(shadow);
+            theme.setItemLabelPaint(Color.BLACK);
+            theme.setThermometerPaint(Color.WHITE);
+            theme.setWallPaint(BarRenderer3D.DEFAULT_WALL_PAINT);
+            theme.setErrorIndicatorPaint(Color.RED);
+            return theme;
+        }
+    };
+    
+    public abstract StandardChartTheme getChartTheme(boolean shadow);
+}

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ColorScheme.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ColorScheme.java
@@ -22,11 +22,11 @@ public enum ColorScheme {
             new Color(0, 255, 0), 
             new Color(32, 32, 32)), 
     COLORFUL(                           // Colorful theme matching the RoboTaxiStatii
-            Color.RED,
-            Color.ORANGE,
-            Color.BLUE,
-            Color.GREEN,
-            Color.LIGHT_GRAY),
+            new Color(255, 0, 0), 
+            new Color(255, 192, 0), 
+            new Color(0, 0, 255), 
+            new Color(0, 255, 0), 
+            new Color(224, 224, 224)), 
     ;
 
     private final Color[] colors;

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ColorScheme.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/ColorScheme.java
@@ -1,0 +1,41 @@
+package ch.ethz.idsc.amodeus.analysis.plot;
+
+import java.awt.Color;
+
+public enum ColorScheme {
+    NONE(                               // One being used right now
+            new Color(255, 85, 85),     // with customer
+            new Color(85, 85, 255),     // to customer
+            new Color(85, 255, 85),     // rebalance
+            new Color(255, 255, 85),    // stay
+            new Color(255, 85, 255)),   // off service
+    STANDARD(                           // Standard colorScheme from Amodeus Viewer
+            new Color(128, 0, 128), 
+            new Color(255, 51, 0),
+            new Color(0, 153, 255), 
+            new Color(0, 204, 0), 
+            new Color(64, 64, 64)), 
+    POP(                                // Poppy colorScheme from Amodeus Viewer
+            new Color(255, 0, 0), 
+            new Color(255, 192, 0), 
+            new Color(0, 224, 255), 
+            new Color(0, 255, 0), 
+            new Color(32, 32, 32)), 
+    COLORFUL(                           // Colorful theme matching the RoboTaxiStatii
+            Color.RED,
+            Color.ORANGE,
+            Color.BLUE,
+            Color.GREEN,
+            Color.LIGHT_GRAY),
+    ;
+
+    private final Color[] colors;
+    
+    private ColorScheme(Color... colors) {
+        this.colors = colors;
+    }
+    
+    public Color of(int index) {
+        return colors[index];
+    }
+}

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
@@ -16,7 +16,7 @@ import org.jfree.ui.RectangleEdge;
 public enum CompositionStack {
     ;
 
-    private static final int WIDTH = 1000; /* Width of the image */
+    private static final int WIDTH = 700; /* Width of the image */
     private static final int HEIGHT = 125; /* Height of the image */
 
     public static void of(File directory, String fileTitle, String diagramTitle, //

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
@@ -6,28 +6,26 @@ import java.io.File;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
-import org.jfree.chart.LegendItem;
-import org.jfree.chart.LegendItemCollection;
 import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.title.LegendTitle;
 import org.jfree.data.category.DefaultCategoryDataset;
 import org.jfree.ui.RectangleEdge;
-import org.jfree.util.SortOrder;
 
 public enum CompositionStack {
     ;
 
-    private static final int WIDTH = 250; /* Width of the image */
-    private static final int HEIGHT = 400; /* Height of the image */
+    private static final int WIDTH = 1000; /* Width of the image */
+    private static final int HEIGHT = 125; /* Height of the image */
 
     public static void of(File directory, String fileTitle, String diagramTitle, //
-            double[] values, String[] labels) throws Exception {
+            double[] values, String[] labels, ColorScheme colorScheme) throws Exception {
 
         DefaultCategoryDataset dataset = new DefaultCategoryDataset();
         for (int i = 0; i < labels.length; ++i) {
             dataset.addValue(values[i], labels[i], "s1");
         }
 
-        JFreeChart chart = ChartFactory.createStackedBarChart(diagramTitle, "", "", dataset, PlotOrientation.VERTICAL, true, false, false);
+        JFreeChart chart = ChartFactory.createStackedBarChart(diagramTitle, "", "", dataset, PlotOrientation.HORIZONTAL, false, false, false);
 
         chart.setBackgroundPaint(Color.white);
         chart.getCategoryPlot().getRangeAxis().setRange(0, 1.0);
@@ -35,16 +33,28 @@ public enum CompositionStack {
         chart.getCategoryPlot().getDomainAxis().setTickLabelsVisible(false);
         chart.getCategoryPlot().getDomainAxis().setLowerMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setUpperMargin(0.0);
-        chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
-        chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
-        LegendItemCollection legend = new LegendItemCollection();
-        legend.add(new LegendItem(labels[0], Color.red));
-        legend.add(new LegendItem(labels[1], Color.blue));
-        legend.add(new LegendItem(labels[2], Color.green));
-        chart.getCategoryPlot().setFixedLegendItems(legend);
-        chart.getLegend().setPosition(RectangleEdge.RIGHT);
-        chart.getLegend().setItemFont(DiagramSettings.FONT_TICK);
-        chart.getLegend().setSortOrder(SortOrder.DESCENDING);
+//        chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        
+        // Adapt colors & style
+        for (int i = 0; i < labels.length; i++) {
+            chart.getCategoryPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
+        }
+        
+//        chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+        
+        LegendTitle legend = new LegendTitle(chart.getCategoryPlot().getRenderer());
+//        legend.setItemFont(DiagramSettings.FONT_TICK);
+        legend.setPosition(RectangleEdge.TOP);
+        chart.addLegend(legend);
+        
+//        LegendItemCollection legend = new LegendItemCollection();
+//        legend.add(new LegendItem(labels[0], Color.red));
+//        legend.add(new LegendItem(labels[1], Color.blue));
+//        legend.add(new LegendItem(labels[2], Color.green));
+//        chart.getCategoryPlot().setFixedLegendItems(legend);
+//        chart.getLegend().setPosition(RectangleEdge.TOP);
+//        chart.getLegend().setItemFont(DiagramSettings.FONT_TICK);
+//        chart.getLegend().setSortOrder(SortOrder.DESCENDING);
 
         StaticHelper.savePlot(directory, fileTitle, chart, WIDTH, HEIGHT);
     }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/CompositionStack.java
@@ -1,12 +1,14 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.analysis.plot;
 
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.io.File;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.renderer.category.StackedBarRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.data.category.DefaultCategoryDataset;
 import org.jfree.ui.RectangleEdge;
@@ -33,28 +35,36 @@ public enum CompositionStack {
         chart.getCategoryPlot().getDomainAxis().setTickLabelsVisible(false);
         chart.getCategoryPlot().getDomainAxis().setLowerMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setUpperMargin(0.0);
-//        chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+
+        StackedBarRenderer renderer = new StackedBarRenderer();
+        renderer.setDrawBarOutline(true);
         
+        chart.getCategoryPlot().setRenderer(renderer);
+
         // Adapt colors & style
         for (int i = 0; i < labels.length; i++) {
             chart.getCategoryPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
+            chart.getCategoryPlot().getRenderer().setSeriesOutlinePaint(i, colorScheme.of(i).darker());
+            chart.getCategoryPlot().getRenderer().setSeriesOutlineStroke(i, new BasicStroke(1.0f));
         }
-        
-//        chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
-        
+
+        // chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+
         LegendTitle legend = new LegendTitle(chart.getCategoryPlot().getRenderer());
-//        legend.setItemFont(DiagramSettings.FONT_TICK);
+        // legend.setItemFont(DiagramSettings.FONT_TICK);
         legend.setPosition(RectangleEdge.TOP);
         chart.addLegend(legend);
-        
-//        LegendItemCollection legend = new LegendItemCollection();
-//        legend.add(new LegendItem(labels[0], Color.red));
-//        legend.add(new LegendItem(labels[1], Color.blue));
-//        legend.add(new LegendItem(labels[2], Color.green));
-//        chart.getCategoryPlot().setFixedLegendItems(legend);
-//        chart.getLegend().setPosition(RectangleEdge.TOP);
-//        chart.getLegend().setItemFont(DiagramSettings.FONT_TICK);
-//        chart.getLegend().setSortOrder(SortOrder.DESCENDING);
+
+        // TODO Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
+        // LegendItemCollection legend = new LegendItemCollection();
+        // legend.add(new LegendItem(labels[0], Color.red));
+        // legend.add(new LegendItem(labels[1], Color.blue));
+        // legend.add(new LegendItem(labels[2], Color.green));
+        // chart.getCategoryPlot().setFixedLegendItems(legend);
+        // chart.getLegend().setPosition(RectangleEdge.TOP);
+        // chart.getLegend().setItemFont(DiagramSettings.FONT_TICK);
+        // chart.getLegend().setSortOrder(SortOrder.DESCENDING);
 
         StaticHelper.savePlot(directory, fileTitle, chart, WIDTH, HEIGHT);
     }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/DiagramSettings.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/DiagramSettings.java
@@ -7,6 +7,7 @@ import java.awt.Font;
 public enum DiagramSettings {
     ;
 
+    // TODO Use ChartTheme instead, which is loaded in Analysis Class and valid for all ChartFactory plots!
     /* package */ static final Font FONT_TITLE = new Font("Dialog", Font.BOLD, 24);
     /* package */ static final Font FONT_AXIS = new Font("Dialog", Font.BOLD, 18);
     /* package */ static final Font FONT_TICK = new Font("Dialog", Font.PLAIN, 14);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/HistogramPlot.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/HistogramPlot.java
@@ -1,6 +1,7 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.analysis.plot;
 
+import java.awt.BasicStroke;
 import java.io.File;
 import java.util.List;
 
@@ -9,6 +10,7 @@ import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryLabelPositions;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.jfree.data.xy.IntervalXYDataset;
 
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.tensor.Tensor;
@@ -31,7 +33,7 @@ public enum HistogramPlot {
      * @throws Exception */
     public static File of(Tensor bins, File directory, String filename, String diagramTitle, //
             double binSize, String axisLabelY, String axisLabelX, //
-            int imageWidth, int imageHeight, String... labels) throws Exception {
+            int imageWidth, int imageHeight, ColorScheme colorScheme, String... labels) throws Exception {
 
         // if input Tensor is vector, convert to tensor
         List<Integer> dim = Dimensions.of(bins);
@@ -49,20 +51,29 @@ public enum HistogramPlot {
                 dataset.addValue(bin.Get(j).number().doubleValue(), labels.length > 0 ? labels[i] : "", binName(binSize, j));
             }
         }
-
+        
         JFreeChart chart = ChartFactory.createBarChart(diagramTitle, axisLabelX, axisLabelY, dataset, //
                 PlotOrientation.VERTICAL, labels.length > 0 ? true : false, false, false);
-        chart.getPlot().setBackgroundPaint(DiagramSettings.COLOR_BACKGROUND_PAINT);
-        chart.getCategoryPlot().setRangeGridlinePaint(DiagramSettings.COLOR_GRIDLINE_PAINT);
-        chart.getCategoryPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
         chart.getCategoryPlot().getDomainAxis().setLowerMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setUpperMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setCategoryMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setCategoryLabelPositions(CategoryLabelPositions.UP_90);
-        chart.getCategoryPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
-        chart.getCategoryPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+        
+        // Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
+        // chart.getPlot().setBackgroundPaint(DiagramSettings.COLOR_BACKGROUND_PAINT);
+        // chart.getCategoryPlot().setRangeGridlinePaint(DiagramSettings.COLOR_GRIDLINE_PAINT);
+        // chart.getCategoryPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // chart.getCategoryPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // chart.getCategoryPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // chart.getCategoryPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // chart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+
+        // Adapt colors & style
+        for (int i = 0; i < dim.size(); i++) {
+            chart.getCategoryPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
+            chart.getCategoryPlot().getRenderer().setSeriesOutlinePaint(i, colorScheme.of(i).darker());
+            chart.getCategoryPlot().getRenderer().setSeriesOutlineStroke(i, new BasicStroke(1.0f));
+        }
 
         return StaticHelper.savePlot(directory, filename, chart, imageWidth, imageHeight);
     }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/HistogramPlot.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/HistogramPlot.java
@@ -2,15 +2,17 @@
 package ch.ethz.idsc.amodeus.analysis.plot;
 
 import java.awt.BasicStroke;
+import java.awt.Color;
 import java.io.File;
 import java.util.List;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.CategoryAnchor;
 import org.jfree.chart.axis.CategoryLabelPositions;
 import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.data.category.DefaultCategoryDataset;
-import org.jfree.data.xy.IntervalXYDataset;
 
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.tensor.Tensor;
@@ -51,15 +53,25 @@ public enum HistogramPlot {
                 dataset.addValue(bin.Get(j).number().doubleValue(), labels.length > 0 ? labels[i] : "", binName(binSize, j));
             }
         }
-        
+
         JFreeChart chart = ChartFactory.createBarChart(diagramTitle, axisLabelX, axisLabelY, dataset, //
                 PlotOrientation.VERTICAL, labels.length > 0 ? true : false, false, false);
         chart.getCategoryPlot().getDomainAxis().setLowerMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setUpperMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setCategoryMargin(0.0);
         chart.getCategoryPlot().getDomainAxis().setCategoryLabelPositions(CategoryLabelPositions.UP_90);
-        
-        // Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
+        chart.getCategoryPlot().setRangeGridlinePaint(Color.lightGray);
+        chart.getCategoryPlot().setRangeGridlinesVisible(true);
+        chart.getCategoryPlot().setDomainGridlinePaint(Color.lightGray);
+        chart.getCategoryPlot().setDomainGridlinesVisible(true);
+        chart.getCategoryPlot().setDomainGridlinePosition(CategoryAnchor.START);
+
+        BarRenderer renderer = new BarRenderer();
+        renderer.setDrawBarOutline(true);
+
+        chart.getCategoryPlot().setRenderer(renderer);
+
+        // TODO Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
         // chart.getPlot().setBackgroundPaint(DiagramSettings.COLOR_BACKGROUND_PAINT);
         // chart.getCategoryPlot().setRangeGridlinePaint(DiagramSettings.COLOR_GRIDLINE_PAINT);
         // chart.getCategoryPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/StackedTimeChart.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/StackedTimeChart.java
@@ -26,7 +26,7 @@ public enum StackedTimeChart {
 
     public static void of(File directory, String fileTitle, String diagramTitle, //
             boolean filter, int filterSize, Double[] scale, //
-            String[] labels, String yAxisLabel, Tensor time, Tensor values) throws Exception {
+            String[] labels, String yAxisLabel, Tensor time, Tensor values, ColorScheme colorScheme) throws Exception {
 
         GlobalAssert.that(time.length() == values.length());
         GlobalAssert.that(Transpose.of(values).length() == labels.length);
@@ -48,7 +48,7 @@ public enum StackedTimeChart {
 
         JFreeChart timechart = ChartFactory.createStackedXYAreaChart(diagramTitle, "Time", //
                 yAxisLabel, dataset, PlotOrientation.VERTICAL, false, false, false);
-
+        
         timechart.getPlot().setBackgroundPaint(Color.white);
         timechart.getXYPlot().setRangeGridlinePaint(Color.lightGray);
         timechart.getXYPlot().setDomainGridlinePaint(Color.lightGray);
@@ -63,6 +63,10 @@ public enum StackedTimeChart {
         timechart.getXYPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
         timechart.getXYPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
         timechart.getXYPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        
+        for (int i = 0; i < labels.length; i++) {
+            timechart.getXYPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
+        }
 
         LegendTitle legend = new LegendTitle(timechart.getXYPlot().getRenderer());
         legend.setItemFont(DiagramSettings.FONT_TICK);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/StackedTimeChart.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/StackedTimeChart.java
@@ -58,18 +58,19 @@ public enum StackedTimeChart {
         timechart.getXYPlot().setDomainAxis(domainAxis);
         timechart.getXYPlot().getDomainAxis().setAutoTickUnitSelection(true);
 
-        timechart.getTitle().setFont(DiagramSettings.FONT_TITLE);
-        timechart.getXYPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        timechart.getXYPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        timechart.getXYPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
-        timechart.getXYPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
-        
+        // TODO Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
+        // timechart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+        // timechart.getXYPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // timechart.getXYPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // timechart.getXYPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // timechart.getXYPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+
         for (int i = 0; i < labels.length; i++) {
             timechart.getXYPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
         }
 
         LegendTitle legend = new LegendTitle(timechart.getXYPlot().getRenderer());
-        legend.setItemFont(DiagramSettings.FONT_TICK);
+        // legend.setItemFont(DiagramSettings.FONT_TICK);
         legend.setPosition(RectangleEdge.TOP);
         timechart.addLegend(legend);
 

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/TimeChart.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/TimeChart.java
@@ -25,7 +25,7 @@ public enum TimeChart {
 
     public static void of(File directory, String fileTitle, String diagramTitle, //
             boolean filter, int filterSize, double[] scale, //
-            String[] labels, String xAxisLabel, String yAxisLabel, Tensor time, Tensor values, double maxRange) throws Exception {
+            String[] labels, String xAxisLabel, String yAxisLabel, Tensor time, Tensor values, double maxRange, ColorScheme colorScheme) throws Exception {
 
         // keep
         GlobalAssert.that(time.length() == values.length());
@@ -58,18 +58,20 @@ public enum TimeChart {
 
         // line thickness
         for (int k = 0; k < time.length(); k++) {
+            timechart.getXYPlot().getRenderer().setSeriesPaint(k, colorScheme.of(k));
             timechart.getXYPlot().getRenderer().setSeriesStroke(k, new BasicStroke(2.0f));
         }
 
+        // Font Text are being set by the general ChartTheme loaded in Main Analysis Class
         // set text fonts
-        timechart.getTitle().setFont(DiagramSettings.FONT_TITLE);
-        timechart.getXYPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        timechart.getXYPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
-        timechart.getXYPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
-        timechart.getXYPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // timechart.getTitle().setFont(DiagramSettings.FONT_TITLE);
+        // timechart.getXYPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // timechart.getXYPlot().getRangeAxis().setLabelFont(DiagramSettings.FONT_AXIS);
+        // timechart.getXYPlot().getDomainAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
+        // timechart.getXYPlot().getRangeAxis().setTickLabelFont(DiagramSettings.FONT_TICK);
 
         LegendTitle legend = new LegendTitle(timechart.getXYPlot().getRenderer());
-        legend.setItemFont(DiagramSettings.FONT_TICK);
+        // legend.setItemFont(DiagramSettings.FONT_TICK);
         legend.setPosition(RectangleEdge.TOP);
         timechart.addLegend(legend);
 

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/TimeChart.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/plot/TimeChart.java
@@ -58,11 +58,16 @@ public enum TimeChart {
 
         // line thickness
         for (int k = 0; k < time.length(); k++) {
-            timechart.getXYPlot().getRenderer().setSeriesPaint(k, colorScheme.of(k));
             timechart.getXYPlot().getRenderer().setSeriesStroke(k, new BasicStroke(2.0f));
         }
 
-        // Font Text are being set by the general ChartTheme loaded in Main Analysis Class
+        // color themes
+        // Adapt colors & style
+        for (int i = 0; i < labels.length; i++) {
+            timechart.getXYPlot().getRenderer().setSeriesPaint(i, colorScheme.of(i));
+        }
+
+        // TODO Does not need to be set anymore since the settings are centralized in ChartTheme for all Chart types
         // set text fonts
         // timechart.getTitle().setFont(DiagramSettings.FONT_TITLE);
         // timechart.getXYPlot().getDomainAxis().setLabelFont(DiagramSettings.FONT_AXIS);

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/report/DistanceElementHtml.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/report/DistanceElementHtml.java
@@ -47,7 +47,7 @@ public class DistanceElementHtml implements HtmlReportElement {
                 "\n" + //
                 "\n" + DECIMAL.format(de.totalDistanceWtCst / de.requestIndices.size()) + " km");
         File img = new File(IMAGE_FOLDER, StackedDistanceChartImage.FILENAME + ".png");
-        aRElement.getHTMLGenerator().insertImgRight(img.getPath(), 250, 400);
+        aRElement.getHTMLGenerator().insertImg(img.getPath(), 700, 125);
         bodyElements.put(aRKey, aRElement);
         return bodyElements;
     }

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/report/WaitingTimesHtml.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/report/WaitingTimesHtml.java
@@ -21,9 +21,9 @@ public class WaitingTimesHtml implements HtmlReportElement {
         HtmlBodyElement aRElement = new HtmlBodyElement();
         aRElement.getHTMLGenerator().insertTextLeft(aRElement.getHTMLGenerator().bold("Waiting Times") + //
                 "\n\tMean:" + //
-                "\n\t" + WaitingTimesElement.QUANTILE1 * 10 + "% quantile:" + //
-                "\n\t" + WaitingTimesElement.QUANTILE2 * 10 + "% quantile:" + //
-                "\n\t" + WaitingTimesElement.QUANTILE3 * 10 + "% quantile:" + //
+                "\n\t" + WaitingTimesElement.QUANTILE1 * 100 + "% quantile:" + //
+                "\n\t" + WaitingTimesElement.QUANTILE2 * 100 + "% quantile:" + //
+                "\n\t" + WaitingTimesElement.QUANTILE3 * 100 + "% quantile:" + //
                 "\n\tMaximum:" //
         );
         aRElement.getHTMLGenerator().insertTextLeft(" " + //

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
@@ -55,6 +55,14 @@ public class ScenarioOptions {
     public String getLinkSpeedDataName() {
         return getString(ScenarioOptionsBase.LINKSPEEDDATAFILENAME);
     }
+    
+    public String getColorScheme() {
+        return getString(ScenarioOptionsBase.COLORSCHEMEIDENTIFIER);
+    }
+    
+    public String getChartTheme() {
+        return getString(ScenarioOptionsBase.CHARTTHEMEIDENTIFIER);
+    }
 
     public LocationSpec getLocationSpec() {
         return LocationSpecs.DATABASE.fromString( //

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
@@ -22,6 +22,8 @@ public enum ScenarioOptionsBase {
     public static final String VIRTUALNETWORKNAMEIDENTIFIER = "virtualNetwork";
     public static final String TRAVELDATAFILENAME = "travelDataFileName";
     public static final String LINKSPEEDDATAFILENAME = "linkSpeedDataFileName";
+    public static final String COLORSCHEMEIDENTIFIER = "colorScheme";
+    public static final String CHARTTHEMEIDENTIFIER = "chartTheme";
     public static final String DTTRAVELDATAIDENTIFIER = "dtTravelData";
     public static final String NUMVNODESIDENTIFIER = "numVirtualNodes";
     public static final String COMPLETEGRAPHIDENTIFIER = "completeGraph";
@@ -45,6 +47,8 @@ public enum ScenarioOptionsBase {
         properties.setProperty(VIRTUALNETWORKNAMEIDENTIFIER, "virtualNetwork");
         properties.setProperty(TRAVELDATAFILENAME, "travelData");
         properties.setProperty(LINKSPEEDDATAFILENAME, "linkSpeedData");
+        properties.setProperty(COLORSCHEMEIDENTIFIER, "NONE");
+        properties.setProperty(CHARTTHEMEIDENTIFIER, "STANDARD");
         properties.setProperty(NETWORKUPDATEDNAMEIDENTIFIER, "preparedNetwork");
         properties.setProperty(POPULATIONUPDATEDNAMEIDENTIFIER, "preparedPopulation");
         properties.setProperty(VIRTUALNETWORKCREATORIDENTIFIER, VirtualNetworkCreators.KMEANS.name());

--- a/src/test/java/ch/ethz/idsc/amodeus/test/AnalysisTestExport.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/AnalysisTestExport.java
@@ -9,6 +9,7 @@ import ch.ethz.idsc.amodeus.analysis.element.DistanceElement;
 import ch.ethz.idsc.amodeus.analysis.element.RequestRobotaxiInformationElement;
 import ch.ethz.idsc.amodeus.analysis.element.StatusDistributionElement;
 import ch.ethz.idsc.amodeus.analysis.element.WaitingTimesElement;
+import ch.ethz.idsc.amodeus.analysis.plot.ColorScheme;
 
 public class AnalysisTestExport implements AnalysisExport {
 
@@ -18,7 +19,7 @@ public class AnalysisTestExport implements AnalysisExport {
     private WaitingTimesElement waitingTimes;
 
     @Override
-    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory) {
+    public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorScheme colorScheme) {
         simulationInformationElement = analysisSummary.getSimulationInformationElement();
         statusDistribution = analysisSummary.getStatusDistribution();
         distanceElement = analysisSummary.getDistanceElement();


### PR DESCRIPTION
New Streamlined Plots (removed the 3D-Bar effect):
- Using ChartTheme and ColorScheme to colorize plots and define the Font Sizes and Style
- ChartTheme and ColorScheme need to be defined in Amodeus.properties
- Standardvalue for ColorScheme to make it look like now: colorScheme=NONE
- Better Colormap: colorScheme=COLORFUL (--> Make it look like the colors used in Amodeus Viewer)
- Spelling Mistakes in Plots corrected
- Wrong QUantile Percentage in ReportHtml corrected