### PR TITLE
Changing the default of the LP Solver to timeInvariant.

### DIFF
--- a/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
@@ -19,7 +19,7 @@ public enum LPOptionsBase {
 
     public static Properties getDefault() {
         Properties properties = new Properties();
-        properties.setProperty(LPSOLVER, "none");
+        properties.setProperty(LPSOLVER, "timeInvariant");
         properties.setProperty(LPWEIGHTQ, "0.99");
         properties.setProperty(LPWEIGHTR, "0.01");
         return properties;


### PR DESCRIPTION
I had several times the problem that for the feed forward Dispatcher no LP Solver could be loaded. This is because the default was set to none. Now I changed this. But saddly i have no idea what exactely this influences. Thus i am happy about any response from you. Let me know if this is a possibility. Btw are the two values 0.99 and 0.01 also somehow meaningfull?

Or would there be another way how we can avoid that its nesscesary to manually change the settings? 

Actually it should be fixed that for the timeinvariant Policy automatically the right LP Solver is chosen. Without changing anything... and similarly for the time variant case. Right?