### PR TITLE
Make working directory configurable

### DIFF
--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/Analysis.java
@@ -200,7 +200,7 @@ public class Analysis {
         analysisExports.add(DistancesRatiosTable.INSTANCE);
         analysisExports.add(WaitingTimesTable.INSTANCE);
         analysisExports.add(StatusDistributionTable.INSTANCE);
-        analysisExports.add(VirtualNetworkExport.INSTANCE);
+        analysisExports.add(new VirtualNetworkExport(scenOptions));
         analysisExports.add(TravelTimeExport.INSTANCE);
         analysisExports.add(WaitingCustomerExport.INSTANCE);
 

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/ScenarioParameters.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/ScenarioParameters.java
@@ -96,7 +96,7 @@ public class ScenarioParameters implements TotalValueAppender, Serializable {
 
         VirtualNetwork<Link> virtualNetwork = null;
         try {
-            virtualNetwork = VirtualNetworkGet.readDefault(network);
+            virtualNetwork = VirtualNetworkGet.readDefault(network, scenOptions);
 
         } catch (IOException e) {
             System.err.println("INFO not able to load virtual network for report");

--- a/src/main/java/ch/ethz/idsc/amodeus/analysis/VirtualNetworkExport.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/analysis/VirtualNetworkExport.java
@@ -8,33 +8,22 @@ import com.google.common.io.Files;
 
 import ch.ethz.idsc.amodeus.analysis.element.AnalysisExport;
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
-import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
-import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.tensor.img.ColorDataIndexed;
 
-public enum VirtualNetworkExport implements AnalysisExport {
-    INSTANCE;
+public class VirtualNetworkExport implements AnalysisExport {
+    private final ScenarioOptions scenarioOptions;
+
+    public VirtualNetworkExport(ScenarioOptions scenarioOptions) {
+        this.scenarioOptions = scenarioOptions;
+    }
 
     @Override
     public void summaryTarget(AnalysisSummary analysisSummary, File relativeDirectory, ColorDataIndexed colorDataIndexed) {
-        File workingDirectory = null;
-        try {
-            workingDirectory = MultiFileTools.getWorkingDirectory();
-        } catch (IOException e) {
-            GlobalAssert.that(false);
-        }
-        ScenarioOptions scenOptions = null;
-        try {
-            scenOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
-        } catch (IOException e) {
-            GlobalAssert.that(false);
-        }
-        final File virtualNetworkFolder = new File(workingDirectory, scenOptions.getVirtualNetworkName());
+        final File virtualNetworkFolder = new File(scenarioOptions.getWorkingDirectory(), scenarioOptions.getVirtualNetworkName());
 
         try {//
-            File virtualNetworkFile = new File(virtualNetworkFolder, scenOptions.getVirtualNetworkName());
-            File copyTo = new File(relativeDirectory, scenOptions.getVirtualNetworkName());
+            File virtualNetworkFile = new File(virtualNetworkFolder, scenarioOptions.getVirtualNetworkName());
+            File copyTo = new File(relativeDirectory, scenarioOptions.getVirtualNetworkName());
             // GlobalAssert.that(virtualNetworkFile.exists());
             // GlobalAssert.that(copyTo.getParentFile().isDirectory());
             System.out.println(virtualNetworkFile);

--- a/src/main/java/ch/ethz/idsc/amodeus/dispatcher/SQMDispatcher.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/dispatcher/SQMDispatcher.java
@@ -160,7 +160,9 @@ public class SQMDispatcher extends PartitionedDispatcher {
 
         @Inject
         private Network network;
-        public static VirtualNetwork<Link> virtualNetwork;
+        
+        @Inject
+        private VirtualNetwork<Link> virtualNetwork;
 
         @Inject
         private Config config;
@@ -172,12 +174,6 @@ public class SQMDispatcher extends PartitionedDispatcher {
         public AVDispatcher createDispatcher(AVDispatcherConfig avconfig, AVRouter router) {
             AVGeneratorConfig generatorConfig = avconfig.getParent().getGeneratorConfig();
 
-            try {
-                virtualNetwork = VirtualNetworkGet.readDefault(network);
-            } catch (IOException e) {
-                e.printStackTrace();
-                GlobalAssert.that(false);
-            }
             return new SQMDispatcher(config, avconfig, travelTime, generatorConfig, router, eventsManager, network, //
                     virtualNetwork, db);
         }

--- a/src/main/java/ch/ethz/idsc/amodeus/dispatcher/SQMDispatcher.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/dispatcher/SQMDispatcher.java
@@ -1,7 +1,6 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.dispatcher;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,7 +25,6 @@ import ch.ethz.idsc.amodeus.net.MatsimAmodeusDatabase;
 import ch.ethz.idsc.amodeus.net.TensorCoords;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
-import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkGet;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNode;
 import ch.ethz.matsim.av.config.AVDispatcherConfig;
 import ch.ethz.matsim.av.config.AVGeneratorConfig;

--- a/src/main/java/ch/ethz/idsc/amodeus/dispatcher/parking/AVSpatialCapacityModule.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/dispatcher/parking/AVSpatialCapacityModule.java
@@ -1,7 +1,6 @@
 /* amodeus - Copyright (c) 2019, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.dispatcher.parking;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.matsim.api.core.v01.network.Network;
@@ -11,11 +10,14 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
-import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 //TODO class not used outside project: document purpose or hide implementation
 public class AVSpatialCapacityModule extends AbstractModule {
+    private final ScenarioOptions scenarioOptions;
+
+    public AVSpatialCapacityModule(ScenarioOptions scenarioOptions) {
+        this.scenarioOptions = scenarioOptions;
+    }
 
     @Override
     public void install() {
@@ -26,7 +28,7 @@ public class AVSpatialCapacityModule extends AbstractModule {
     @Singleton
     public AVSpatialCapacityAmodeus provideAVSpatialCapacity(Network network) {
         try {
-            return loadSpatialCapacity(network);
+            return loadSpatialCapacity(network, scenarioOptions);
         } catch (IOException ioException) {
             System.err.println("We could not load the Spatial Capacity of all the Links");
             ioException.printStackTrace();
@@ -35,9 +37,7 @@ public class AVSpatialCapacityModule extends AbstractModule {
         return null;
     }
 
-    private static AVSpatialCapacityAmodeus loadSpatialCapacity(Network network) throws IOException {
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
-        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+    private static AVSpatialCapacityAmodeus loadSpatialCapacity(Network network, ScenarioOptions scenarioOptions) throws IOException {
         return scenarioOptions.getParkingCapacityGenerator().generate(network);
     }
 

--- a/src/main/java/ch/ethz/idsc/amodeus/dispatcher/util/FeedForwardTravelData.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/dispatcher/util/FeedForwardTravelData.java
@@ -15,11 +15,9 @@ import ch.ethz.idsc.amodeus.lp.LPSolver;
 import ch.ethz.idsc.amodeus.options.LPOptions;
 import ch.ethz.idsc.amodeus.options.LPOptionsBase;
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
-import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.traveldata.StaticTravelData;
 import ch.ethz.idsc.amodeus.traveldata.StaticTravelDataCreator;
 import ch.ethz.idsc.amodeus.traveldata.TravelDataIO;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.io.ProvideAVConfig;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.tensor.Tensor;
@@ -30,13 +28,9 @@ import ch.ethz.matsim.av.framework.AVConfigGroup;
 public enum FeedForwardTravelData {
     ;
 
-    public static void overwriteIfRequired(LPCreator lpCreator, StaticTravelData travelData, VirtualNetwork<Link> virtualNetwork) {
+    public static void overwriteIfRequired(LPCreator lpCreator, StaticTravelData travelData, VirtualNetwork<Link> virtualNetwork, ScenarioOptions scenarioOptions) {
         if (!travelData.getLPName().equals(lpCreator.name())) {
             try {
-                /** amodeus options */
-                File workingDirectory = MultiFileTools.getWorkingDirectory();
-                ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
-
                 /** MATSim config */
                 AVConfigGroup avConfigGroup = new AVConfigGroup();
                 Config config = ConfigUtils.loadConfig(scenarioOptions.getSimulationConfigName(), avConfigGroup);
@@ -53,7 +47,7 @@ public enum FeedForwardTravelData {
                 Tensor lambdaAbsolute = StaticTravelDataCreator.getLambdaAbsolute( //
                         scenario.getNetwork(), virtualNetwork, //
                         scenario.getPopulation(), scenarioOptions.getdtTravelData(), endTime);
-                LPOptions lpOptions = new LPOptions(workingDirectory, LPOptionsBase.getDefault());
+                LPOptions lpOptions = new LPOptions(scenarioOptions.getWorkingDirectory(), LPOptionsBase.getDefault());
                 System.out.println("Loaded the Lp Options");
 
                 LPSolver lpSolver = lpCreator.create(virtualNetwork, scenario.getNetwork(), lpOptions, lambdaAbsolute, numRt, endTime);

--- a/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusComponent.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusComponent.java
@@ -8,6 +8,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -20,12 +21,23 @@ import org.matsim.api.core.v01.Coord;
 import ch.ethz.idsc.amodeus.net.MatsimAmodeusDatabase;
 import ch.ethz.idsc.amodeus.net.SimulationObject;
 import ch.ethz.idsc.amodeus.util.gui.GraphicsUtil;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.view.jmapviewer.AmodeusHeatMap;
 import ch.ethz.idsc.amodeus.view.jmapviewer.Coordinate;
 import ch.ethz.idsc.amodeus.view.jmapviewer.JMapViewer;
 import ch.ethz.idsc.amodeus.view.jmapviewer.interfaces.ICoordinate;
 
 public class AmodeusComponent extends JMapViewer {
+    
+    @Deprecated
+    /** Should not be used in amodeus repository anymore */
+    public static AmodeusComponent createDefault(MatsimAmodeusDatabase db) {
+        try {
+            return createDefault(db, MultiFileTools.getDefaultWorkingDirectory());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /** @param db
      * @return instance of MatsimMapComponent with default sequence of {@link ViewerLayer}s */

--- a/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusComponent.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusComponent.java
@@ -7,6 +7,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,7 +29,7 @@ public class AmodeusComponent extends JMapViewer {
 
     /** @param db
      * @return instance of MatsimMapComponent with default sequence of {@link ViewerLayer}s */
-    public static AmodeusComponent createDefault(MatsimAmodeusDatabase db) {
+    public static AmodeusComponent createDefault(MatsimAmodeusDatabase db, File workingDirectory) {
         AmodeusComponent amodeusComponent = new AmodeusComponent(db);
         amodeusComponent.addLayer(new TilesLayer(amodeusComponent));
         amodeusComponent.addLayer(new VirtualNetworkLayer(amodeusComponent));
@@ -38,7 +39,7 @@ public class AmodeusComponent extends JMapViewer {
         amodeusComponent.addLayer(new LoadLayer(amodeusComponent));
         amodeusComponent.addLayer(new HudLayer(amodeusComponent));
         amodeusComponent.addLayer(new ClockLayer(amodeusComponent));
-        amodeusComponent.addLayer(new VideoLayer(amodeusComponent));
+        amodeusComponent.addLayer(new VideoLayer(amodeusComponent, workingDirectory));
         return amodeusComponent;
     }
 

--- a/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusViewerFrame.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusViewerFrame.java
@@ -33,6 +33,7 @@ import ch.ethz.idsc.amodeus.net.IterationFolder;
 import ch.ethz.idsc.amodeus.net.SimulationFolderUtils;
 import ch.ethz.idsc.amodeus.net.StorageSupplier;
 import ch.ethz.idsc.amodeus.net.StorageUtils;
+import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.util.gui.RowPanel;
 import ch.ethz.idsc.amodeus.util.gui.SpinnerLabel;
 import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
@@ -55,6 +56,7 @@ public class AmodeusViewerFrame implements Runnable {
     private int playbackSpeed = 50;
     private final Thread thread;
     private StorageUtils storageUtils;
+    private final ScenarioOptions scenarioOptions;
 
     public final JFrame jFrame = new JFrame();
     private StorageSupplier storageSupplier = new DummyStorageSupplier();
@@ -68,8 +70,8 @@ public class AmodeusViewerFrame implements Runnable {
     private final Network network;
 
     /** the new constructor is public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File workingDirectory, File defaultDirectory) */
-    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, Network network) {
-        this(amodeusComponent, outputDirectory, outputDirectory, network);
+    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, Network network, ScenarioOptions scenarioOptions) {
+        this(amodeusComponent, outputDirectory, outputDirectory, network, scenarioOptions);
     }
 
     /** Constructs the {@code Demo}.
@@ -78,8 +80,9 @@ public class AmodeusViewerFrame implements Runnable {
      * @param outputDirectory
      * @param defaultDirectory TODO Joel document difference to outputDirectory
      * @param network */
-    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, File defaultDirectory, Network network) {
+    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, File defaultDirectory, Network network, ScenarioOptions scenarioOptions) {
         this.network = network;
+        this.scenarioOptions = scenarioOptions;
         this.amodeusComponent = amodeusComponent;
         // ---
         jFrame.setTitle(TITLE);
@@ -232,7 +235,7 @@ public class AmodeusViewerFrame implements Runnable {
 
     void setVirtualNetwork(File selectedDirectory) {
         try {
-            amodeusComponent.virtualNetworkLayer.setVirtualNetwork(VirtualNetworkGet.readFromOutputDirectory(network, selectedDirectory));
+            amodeusComponent.virtualNetworkLayer.setVirtualNetwork(VirtualNetworkGet.readFromOutputDirectory(network, selectedDirectory, scenarioOptions));
         } catch (IOException e) {
             GlobalAssert.that(false);
         }

--- a/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusViewerFrame.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/gfx/AmodeusViewerFrame.java
@@ -34,6 +34,7 @@ import ch.ethz.idsc.amodeus.net.SimulationFolderUtils;
 import ch.ethz.idsc.amodeus.net.StorageSupplier;
 import ch.ethz.idsc.amodeus.net.StorageUtils;
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
+import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.util.gui.RowPanel;
 import ch.ethz.idsc.amodeus.util.gui.SpinnerLabel;
 import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
@@ -68,6 +69,30 @@ public class AmodeusViewerFrame implements Runnable {
     private final SpinnerLabel<Integer> spinnerLabelSpeed = new SpinnerLabel<>();
     private final JSlider jSlider = new JSlider(0, 1, 0);
     private final Network network;
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, Network network) {
+        this(amodeusComponent, outputDirectory, outputDirectory, network);
+    }
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, File defaultDirectory, Network network) {
+        // We need to do the detour through that function here, because there cannot be a try block wrapping the delegated constructor
+        this(amodeusComponent, outputDirectory, defaultDirectory, network, createDeprecatedScenarioOptions());
+    }
+
+    @Deprecated
+    private static ScenarioOptions createDeprecatedScenarioOptions() {
+        try {
+            File workingDirectory = MultiFileTools.getWorkingDirectory();
+            return new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+        } catch (IOException e) {
+            GlobalAssert.that(false);
+            return null;
+        }
+    }
 
     /** the new constructor is public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File workingDirectory, File defaultDirectory) */
     public AmodeusViewerFrame(AmodeusComponent amodeusComponent, File outputDirectory, Network network, ScenarioOptions scenarioOptions) {

--- a/src/main/java/ch/ethz/idsc/amodeus/gfx/VideoLayer.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/gfx/VideoLayer.java
@@ -4,6 +4,7 @@ package ch.ethz.idsc.amodeus.gfx;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Graphics2D;
+import java.io.File;
 import java.io.IOException;
 import java.util.stream.IntStream;
 
@@ -13,18 +14,19 @@ import javax.swing.JPanel;
 import ch.ethz.idsc.amodeus.net.SimulationObject;
 import ch.ethz.idsc.amodeus.util.gui.RowPanel;
 import ch.ethz.idsc.amodeus.util.gui.SpinnerLabel;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.video.VideoGenerator;
 
 /** Head Up Display */
 public class VideoLayer extends ViewerLayer {
+    private final File workingDirectory;
 
     private int fps;
     private int startTime;
     private int endTime;
 
-    public VideoLayer(AmodeusComponent amodeusComponent) {
+    public VideoLayer(AmodeusComponent amodeusComponent, File workingDirectory) {
         super(amodeusComponent);
+        this.workingDirectory = workingDirectory;
     }
 
     @Override
@@ -40,7 +42,7 @@ public class VideoLayer extends ViewerLayer {
             jButton.addActionListener(event -> {
                 try {
                     ViewerConfig viewerConfig = ViewerConfig.fromDefaults(amodeusComponent.db);
-                    viewerConfig.save(amodeusComponent, MultiFileTools.getWorkingDirectory());
+                    viewerConfig.save(amodeusComponent, workingDirectory);
                     System.out.println(viewerConfig);
                 } catch (IOException e) {
                     e.printStackTrace();
@@ -52,11 +54,7 @@ public class VideoLayer extends ViewerLayer {
             JButton jButton = new JButton("record");
             jButton.setToolTipText("record video with settings found in working directory or defaults");
             jButton.addActionListener(event -> {
-                try {
-                    (new VideoGenerator(MultiFileTools.getWorkingDirectory())).start();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+                (new VideoGenerator(workingDirectory)).start();
             });
             rowPanel.add(jButton);
         }

--- a/src/main/java/ch/ethz/idsc/amodeus/lp/LPPreparer.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/lp/LPPreparer.java
@@ -1,6 +1,8 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.lp;
 
+import java.io.File;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 
@@ -14,10 +16,10 @@ public enum LPPreparer {
     ;
 
     /** Solves the LP by the given solver and returns the solver where the LP solution can be taken out if it */
-    public static LPSolver run(VirtualNetwork<Link> virtualNetwork, //
+    public static LPSolver run(File workingDirectory, VirtualNetwork<Link> virtualNetwork, //
             Network network, Tensor lambdaAbsolute, int numberOfVehicles, int endTime) throws Exception {
 
-        LPOptions lpOptions = new LPOptions(MultiFileTools.getWorkingDirectory(), LPOptionsBase.getDefault());
+        LPOptions lpOptions = new LPOptions(workingDirectory, LPOptionsBase.getDefault());
 
         LPCreator lpCreator = lpOptions.getLPSolver();
         LPSolver solver = lpCreator.create(virtualNetwork, network, lpOptions, lambdaAbsolute, numberOfVehicles, endTime);

--- a/src/main/java/ch/ethz/idsc/amodeus/lp/LPPreparer.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/lp/LPPreparer.java
@@ -8,7 +8,6 @@ import org.matsim.api.core.v01.network.Network;
 
 import ch.ethz.idsc.amodeus.options.LPOptions;
 import ch.ethz.idsc.amodeus.options.LPOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.tensor.Tensor;
 

--- a/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusVirtualNetworkModule.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusVirtualNetworkModule.java
@@ -1,6 +1,7 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.matsim.mod;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.matsim.api.core.v01.network.Link;
@@ -11,9 +12,11 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
+import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkPreparer;
 import ch.ethz.idsc.amodeus.traveldata.TravelData;
 import ch.ethz.idsc.amodeus.traveldata.TravelDataGet;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkGet;
 
@@ -23,6 +26,17 @@ public class AmodeusVirtualNetworkModule extends AbstractModule {
 
     public AmodeusVirtualNetworkModule(ScenarioOptions scenarioOptions) {
         this.scenarioOptions = scenarioOptions;
+    }
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public AmodeusVirtualNetworkModule() {
+        try {
+            File workingDirectory = MultiFileTools.getWorkingDirectory();
+            this.scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusVirtualNetworkModule.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusVirtualNetworkModule.java
@@ -10,6 +10,7 @@ import org.matsim.core.controler.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
+import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkPreparer;
 import ch.ethz.idsc.amodeus.traveldata.TravelData;
 import ch.ethz.idsc.amodeus.traveldata.TravelDataGet;
@@ -18,6 +19,12 @@ import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkGet;
 
 /** provides the {@link VirtualNetwork} and {@link TravelData} and therefore {@link VirtualNetworkPreparer} has to be run in the Preparer */
 public class AmodeusVirtualNetworkModule extends AbstractModule {
+    private final ScenarioOptions scenarioOptions;
+
+    public AmodeusVirtualNetworkModule(ScenarioOptions scenarioOptions) {
+        this.scenarioOptions = scenarioOptions;
+    }
+
     @Override
     public void install() {
         // ---
@@ -27,7 +34,7 @@ public class AmodeusVirtualNetworkModule extends AbstractModule {
     @Singleton
     public VirtualNetwork<Link> provideVirtualNetwork(Network network) {
         try {
-            return VirtualNetworkGet.readDefault(network);
+            return VirtualNetworkGet.readDefault(network, scenarioOptions);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -37,7 +44,7 @@ public class AmodeusVirtualNetworkModule extends AbstractModule {
     @Singleton
     public TravelData provideTravelData(VirtualNetwork<Link> virtualNetwork) {
         try {
-            return TravelDataGet.readStatic(virtualNetwork);
+            return TravelDataGet.readStatic(virtualNetwork, scenarioOptions);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/ch/ethz/idsc/amodeus/options/LPOptions.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/LPOptions.java
@@ -6,10 +6,23 @@ import java.io.IOException;
 import java.util.Properties;
 
 import ch.ethz.idsc.amodeus.lp.LPCreator;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public class LPOptions {
     private final File workingDirectory;
     protected final Properties properties;
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    protected LPOptions(Properties properties) {
+        this.properties = properties;
+
+        try {
+            this.workingDirectory = MultiFileTools.getDefaultWorkingDirectory();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public LPOptions(File workingDirectory, Properties fallbackDefault) throws IOException {
         this.workingDirectory = workingDirectory;

--- a/src/main/java/ch/ethz/idsc/amodeus/options/LPOptions.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/LPOptions.java
@@ -8,14 +8,11 @@ import java.util.Properties;
 import ch.ethz.idsc.amodeus.lp.LPCreator;
 
 public class LPOptions {
-
+    private final File workingDirectory;
     protected final Properties properties;
 
-    protected LPOptions(Properties properties) {
-        this.properties = properties;
-    }
-
     public LPOptions(File workingDirectory, Properties fallbackDefault) throws IOException {
+        this.workingDirectory = workingDirectory;
         this.properties = StaticHelper.loadOrCreateLPOptions(workingDirectory, fallbackDefault);
     }
 
@@ -26,7 +23,7 @@ public class LPOptions {
     }
 
     public void saveAndOverwriteLPOptions() throws IOException {
-        LPOptionsBase.saveProperties(properties);
+        LPOptionsBase.saveProperties(workingDirectory, properties);
     }
 
     public void saveToFolder(File folder, String header) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
@@ -25,8 +25,8 @@ public enum LPOptionsBase {
         return properties;
     }
 
-    public static void saveProperties(Properties prop) throws IOException {
-        saveProperties(prop, new File(OPTIONSFILENAME));
+    public static void saveProperties(File workingDirectory, Properties prop) throws IOException {
+        saveProperties(prop, new File(workingDirectory, OPTIONSFILENAME));
     }
 
     public static void saveProperties(Properties prop, File file) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/LPOptionsBase.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import ch.ethz.idsc.amodeus.util.io.FileLines;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public enum LPOptionsBase {
     ;
@@ -23,6 +24,12 @@ public enum LPOptionsBase {
         properties.setProperty(LPWEIGHTQ, "0.99");
         properties.setProperty(LPWEIGHTR, "0.01");
         return properties;
+    }
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public static void saveProperties(Properties prop) throws IOException {
+        saveProperties(MultiFileTools.getDefaultWorkingDirectory(), prop);
     }
 
     public static void saveProperties(File workingDirectory, Properties prop) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
@@ -15,15 +15,16 @@ import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreators;
 
 public class ScenarioOptions {
-
+    private final File workingDirectory;
     protected final Properties properties;
 
-    protected ScenarioOptions(Properties properties) {
-        this.properties = properties;
-    }
-
     public ScenarioOptions(File workingDirectory, Properties fallbackDefault) throws IOException {
+        this.workingDirectory = workingDirectory;
         this.properties = StaticHelper.loadOrCreateScenarioOptions(workingDirectory, fallbackDefault);
+    }
+    
+    public File getWorkingDirectory() {
+        return workingDirectory;
     }
 
     // PROPERTIES FUNCTIONS
@@ -33,7 +34,7 @@ public class ScenarioOptions {
     }
 
     public void saveAndOverwriteAmodeusOptions() throws IOException {
-        ScenarioOptionsBase.saveProperties(properties);
+        ScenarioOptionsBase.saveProperties(workingDirectory, properties);
     }
 
     public void saveToFolder(File folder, String header) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptions.java
@@ -13,16 +13,28 @@ import ch.ethz.idsc.amodeus.prep.PopulationCutter;
 import ch.ethz.idsc.amodeus.prep.PopulationCutters;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreators;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public class ScenarioOptions {
     private final File workingDirectory;
     protected final Properties properties;
 
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    protected ScenarioOptions(Properties properties) {
+        try {
+            this.workingDirectory = MultiFileTools.getDefaultWorkingDirectory();
+            this.properties = properties;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public ScenarioOptions(File workingDirectory, Properties fallbackDefault) throws IOException {
         this.workingDirectory = workingDirectory;
         this.properties = StaticHelper.loadOrCreateScenarioOptions(workingDirectory, fallbackDefault);
     }
-    
+
     public File getWorkingDirectory() {
         return workingDirectory;
     }

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
@@ -10,6 +10,7 @@ import ch.ethz.idsc.amodeus.dispatcher.parking.AVSpatialCapacityGenerators;
 import ch.ethz.idsc.amodeus.prep.PopulationCutters;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreators;
 import ch.ethz.idsc.amodeus.util.io.FileLines;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public enum ScenarioOptionsBase {
     ;
@@ -66,6 +67,12 @@ public enum ScenarioOptionsBase {
         properties.setProperty(PARKINGGENERATORIDENTIFIER, AVSpatialCapacityGenerators.NONE.name());
         properties.setProperty(PARKINGSPOTSTAGIDENTIFIER, "spatialAvCapacity");
         return properties;
+    }
+    
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public static void saveProperties(Properties prop) throws IOException {
+        saveProperties(prop, new File(MultiFileTools.getDefaultWorkingDirectory(), OPTIONSFILENAME));
     }
 
     public static void saveProperties(File workingDirectory, Properties prop) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/options/ScenarioOptionsBase.java
@@ -68,8 +68,8 @@ public enum ScenarioOptionsBase {
         return properties;
     }
 
-    public static void saveProperties(Properties prop) throws IOException {
-        saveProperties(prop, new File(OPTIONSFILENAME));
+    public static void saveProperties(File workingDirectory, Properties prop) throws IOException {
+        saveProperties(prop, new File(workingDirectory, OPTIONSFILENAME));
     }
 
     public static void saveProperties(Properties prop, File file) throws IOException {

--- a/src/main/java/ch/ethz/idsc/amodeus/prep/VirtualNetworkPreparer.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/prep/VirtualNetworkPreparer.java
@@ -12,7 +12,6 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.traveldata.StaticTravelData;
 import ch.ethz.idsc.amodeus.traveldata.StaticTravelDataCreator;
 import ch.ethz.idsc.amodeus.traveldata.TravelDataIO;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkIO;
@@ -36,10 +35,11 @@ public enum VirtualNetworkPreparer implements VirtualNetworkCreator {
             System.out.println("saved virtual network byte format to : " + new File(vnDir, scenarioOptions.getVirtualNetworkName()));
 
             virtualNetwork.printVirtualNetworkInfo();
-            System.out.println("successfully converted simulation data files from in " + MultiFileTools.getWorkingDirectory());
+            System.out.println("successfully converted simulation data files from in " + scenarioOptions.getWorkingDirectory());
 
             /** reading the whole travel data */
-            StaticTravelData travelData = StaticTravelDataCreator.create(virtualNetwork, network, population, scenarioOptions.getdtTravelData(), numVehicles, endTime);
+            StaticTravelData travelData = StaticTravelDataCreator.create(scenarioOptions.getWorkingDirectory(), virtualNetwork, network, population,
+                    scenarioOptions.getdtTravelData(), numVehicles, endTime);
 
             File travelDataFile = new File(scenarioOptions.getVirtualNetworkName(), scenarioOptions.getTravelDataName());
             TravelDataIO.writeStatic(travelDataFile, travelData);

--- a/src/main/java/ch/ethz/idsc/amodeus/simulation/SimulationProperties.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/simulation/SimulationProperties.java
@@ -17,7 +17,6 @@ import ch.ethz.idsc.amodeus.data.LocationSpecDatabase;
 import ch.ethz.idsc.amodeus.net.MatsimAmodeusDatabase;
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.matsim.av.framework.AVConfigGroup;
 

--- a/src/main/java/ch/ethz/idsc/amodeus/simulation/SimulationProperties.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/simulation/SimulationProperties.java
@@ -41,10 +41,10 @@ public class SimulationProperties {
     /** Loads the simulation properties without throwing an exception.
      * 
      * @return {@link SimulationProperties} */
-    public static SimulationProperties load() {
+    public static SimulationProperties load(File workingDirectory) {
         SimulationProperties simulationProperties = null;
         try {
-            simulationProperties = new SimulationProperties();
+            simulationProperties = new SimulationProperties(workingDirectory);
         } catch (IOException e) {
             System.err.println(
                     "Luckily we were able to stop the process before runing the simulation with incomplete settings. Who knows what would happen then... You are our last chance! Help me please I desire to run even more than you do.");
@@ -55,10 +55,10 @@ public class SimulationProperties {
     }
 
     /** To use this class the LocationSpecDatabase has to be set up in advance. This can be done with the Helper Class "Static" */
-    protected SimulationProperties() throws IOException {
+    protected SimulationProperties(File workingDirectory) throws IOException {
         GlobalAssert.that(!LocationSpecDatabase.INSTANCE.isEmpty());
 
-        workingDirectory = MultiFileTools.getWorkingDirectory();
+        this.workingDirectory = workingDirectory;
         scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
 
         // Locationspec needs to be set manually in Amodeus.properties

--- a/src/main/java/ch/ethz/idsc/amodeus/traveldata/StaticTravelDataCreator.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/traveldata/StaticTravelDataCreator.java
@@ -1,6 +1,7 @@
 /* amodeus - Copyright (c) 2018, ETH Zurich, Institute for Dynamic Systems and Control */
 package ch.ethz.idsc.amodeus.traveldata;
 
+import java.io.File;
 import java.util.Set;
 
 import org.matsim.api.core.v01.network.Link;
@@ -17,11 +18,11 @@ import ch.ethz.idsc.tensor.Tensor;
 public enum StaticTravelDataCreator {
     ;
     /** Creates the travel data by counting all travel requests and solving an LP depending on this request information */
-    public static StaticTravelData create(VirtualNetwork<Link> virtualNetwork, Network network, Population population, int interval, int numberOfVehicles, int endTime)
-            throws Exception {
+    public static StaticTravelData create(File workingDirectory, VirtualNetwork<Link> virtualNetwork, Network network, Population population, int interval, int numberOfVehicles,
+            int endTime) throws Exception {
         Tensor lambdaAbsolute = getLambdaAbsolute(network, virtualNetwork, population, interval, endTime);
 
-        LPSolver lpSolver = LPPreparer.run(virtualNetwork, network, lambdaAbsolute, numberOfVehicles, endTime);
+        LPSolver lpSolver = LPPreparer.run(workingDirectory, virtualNetwork, network, lambdaAbsolute, numberOfVehicles, endTime);
 
         String lpName = lpSolver.getClass().getSimpleName();
         Tensor alphaAbsolute = lpSolver.getAlphaAbsolute_ij();

--- a/src/main/java/ch/ethz/idsc/amodeus/traveldata/TravelDataGet.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/traveldata/TravelDataGet.java
@@ -8,11 +8,21 @@ import java.util.Objects;
 import org.matsim.api.core.v01.network.Link;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
+import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 
 public enum TravelDataGet {
     ;
+
+    @Deprecated
+    /** Should not be used in amodeus repository anymore! */
+    public static TravelData readStatic(VirtualNetwork<Link> virtualNetwork) throws IOException {
+        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+        return readStatic(virtualNetwork, scenarioOptions);
+    }
 
     public static StaticTravelData readStatic(VirtualNetwork<Link> virtualNetwork, ScenarioOptions scenarioOptions) throws IOException {
         GlobalAssert.that(Objects.nonNull(virtualNetwork));

--- a/src/main/java/ch/ethz/idsc/amodeus/traveldata/TravelDataGet.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/traveldata/TravelDataGet.java
@@ -8,18 +8,14 @@ import java.util.Objects;
 import org.matsim.api.core.v01.network.Link;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
-import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 
 public enum TravelDataGet {
     ;
 
-    public static StaticTravelData readStatic(VirtualNetwork<Link> virtualNetwork) throws IOException {
+    public static StaticTravelData readStatic(VirtualNetwork<Link> virtualNetwork, ScenarioOptions scenarioOptions) throws IOException {
         GlobalAssert.that(Objects.nonNull(virtualNetwork));
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
-        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
         final File travelDataFile = new File(scenarioOptions.getVirtualNetworkName(), //
                 scenarioOptions.getTravelDataName());
         System.out.println("loading travelData from " + travelDataFile.getAbsoluteFile());

--- a/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
@@ -12,7 +12,7 @@ public enum MultiFileTools {
 
     /** @return {@link File} of current working directory
      * @throws IOException */
-    public static File getWorkingDirectory() throws IOException {
+    private static File getWorkingDirectory() throws IOException {
         return new File("").getCanonicalFile();
     }
 

--- a/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
@@ -13,6 +13,12 @@ public enum MultiFileTools {
     public static File getDefaultWorkingDirectory() throws IOException {
         return new File(".").getCanonicalFile();
     }
+    
+    @Deprecated
+    /** Should not be used in amodeus repository anymore! */
+    public static File getWorkingDirectory() throws IOException {
+        return new File(".").getCanonicalFile();
+    }
 
     /** @return all directories in filesDirectory sorted by name */
     public static File[] getAllDirectoriesSorted(File filesDirectory) {

--- a/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
@@ -2,12 +2,17 @@
 package ch.ethz.idsc.amodeus.util.io;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 
 public enum MultiFileTools {
     ;
+
+    public static File getDefaultWorkingDirectory() throws IOException {
+        return new File(".").getCanonicalFile();
+    }
 
     /** @return all directories in filesDirectory sorted by name */
     public static File[] getAllDirectoriesSorted(File filesDirectory) {

--- a/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/util/io/MultiFileTools.java
@@ -2,19 +2,12 @@
 package ch.ethz.idsc.amodeus.util.io;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.stream.Stream;
 
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 
 public enum MultiFileTools {
     ;
-
-    /** @return {@link File} of current working directory
-     * @throws IOException */
-    private static File getWorkingDirectory() throws IOException {
-        return new File("").getCanonicalFile();
-    }
 
     /** @return all directories in filesDirectory sorted by name */
     public static File[] getAllDirectoriesSorted(File filesDirectory) {

--- a/src/main/java/ch/ethz/idsc/amodeus/video/VideoGenerator.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/video/VideoGenerator.java
@@ -116,7 +116,7 @@ public class VideoGenerator implements Runnable {
 
         /** this is optional and should not cause problems if file does not
          * exist. temporary solution */
-        VirtualNetwork<Link> virtualNetwork = VirtualNetworkGet.readDefault(network); // may be null
+        VirtualNetwork<Link> virtualNetwork = VirtualNetworkGet.readDefault(network, scenarioOptions); // may be null
         System.out.println("has vn: " + (virtualNetwork != null));
         VirtualNetworkLayer virtualNetworkLayer = new VirtualNetworkLayer(amodeusComponent);
         virtualNetworkLayer.setVirtualNetwork(virtualNetwork);

--- a/src/main/java/ch/ethz/idsc/amodeus/virtualnetwork/core/VirtualNetworkGet.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/virtualnetwork/core/VirtualNetworkGet.java
@@ -10,8 +10,6 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
-import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public enum VirtualNetworkGet {
     ;
@@ -19,9 +17,7 @@ public enum VirtualNetworkGet {
     /** @param network
      * @return null if file does not exist
      * @throws IOException */
-    public static VirtualNetwork<Link> readDefault(Network network) throws IOException {
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
-        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+    public static VirtualNetwork<Link> readDefault(Network network, ScenarioOptions scenarioOptions) throws IOException {
         final File virtualnetworkFile = new File(scenarioOptions.getVirtualNetworkName(), scenarioOptions.getVirtualNetworkName());
         System.out.println("reading network from" + virtualnetworkFile.getAbsoluteFile());
         try {
@@ -40,9 +36,7 @@ public enum VirtualNetworkGet {
     /** @param network
      * @return null if file does not exist
      * @throws IOException */
-    public static VirtualNetwork<Link> readFromOutputDirectory(Network network, File outputDirectory) throws IOException {
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
-        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+    public static VirtualNetwork<Link> readFromOutputDirectory(Network network, File outputDirectory, ScenarioOptions scenarioOptions) throws IOException {
         final File virtualnetworkFolder = new File(outputDirectory, "data"); // TODO Joel still hard-coded, search for "data" in project
         final File virtualnetworkFile = new File(virtualnetworkFolder, scenarioOptions.getVirtualNetworkName());
         System.out.println("reading virtual network from" + virtualnetworkFile.getAbsoluteFile());
@@ -52,17 +46,15 @@ public enum VirtualNetworkGet {
             return VirtualNetworkIO.fromByte(map, virtualnetworkFile);
         } catch (Exception e) {
             System.out.println("cannot load default " + virtualnetworkFile);
-            return readFromWorkingDirectory(network);
+            return readFromWorkingDirectory(network, scenarioOptions);
         }
     }
 
     /** @param network
      * @return null if file does not exist
      * @throws IOException */
-    public static VirtualNetwork<Link> readFromWorkingDirectory(Network network) throws IOException {
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
-        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
-        final File virtualnetworkFolder = new File(workingDirectory, scenarioOptions.getVirtualNetworkName());
+    public static VirtualNetwork<Link> readFromWorkingDirectory(Network network, ScenarioOptions scenarioOptions) throws IOException {
+        final File virtualnetworkFolder = new File(scenarioOptions.getWorkingDirectory(), scenarioOptions.getVirtualNetworkName());
         final File virtualnetworkFile = new File(virtualnetworkFolder, scenarioOptions.getVirtualNetworkName());
         System.out.println("reading virtual network from" + virtualnetworkFile.getAbsoluteFile());
         try {

--- a/src/main/java/ch/ethz/idsc/amodeus/virtualnetwork/core/VirtualNetworkGet.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/virtualnetwork/core/VirtualNetworkGet.java
@@ -10,9 +10,19 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
+import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
+import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 public enum VirtualNetworkGet {
     ;
+    
+    @Deprecated
+    /** Should not be used in amodeus repository anymore. */
+    public static VirtualNetwork<Link> readDefault(Network network) throws IOException {
+        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
+        return readDefault(network, scenarioOptions);
+    }
 
     /** @param network
      * @return null if file does not exist

--- a/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeInvariantTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeInvariantTest.java
@@ -23,7 +23,6 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.io.ProvideAVConfig;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;

--- a/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeInvariantTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeInvariantTest.java
@@ -46,7 +46,7 @@ public class LPTimeInvariantTest {
         System.out.println(LPTimeInvariant.class.getName());
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 

--- a/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeVariantTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeVariantTest.java
@@ -25,7 +25,6 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.io.ProvideAVConfig;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;

--- a/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeVariantTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/lp/LPTimeVariantTest.java
@@ -48,7 +48,7 @@ public class LPTimeVariantTest {
         System.out.println(LPTimeVariant.class.getName());
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 
@@ -76,7 +76,7 @@ public class LPTimeVariantTest {
         virtualNetworkCreator = scenarioOptions.getVirtualNetworkCreator();
         virtualNetwork3 = virtualNetworkCreator.create(network, population, scenarioOptions, numRt, endTime);
 
-        lpOptions = new LPOptions(MultiFileTools.getWorkingDirectory(), LPOptionsBase.getDefault());
+        lpOptions = new LPOptions(workingDirectory, LPOptionsBase.getDefault());
     }
 
     @Test

--- a/src/test/java/ch/ethz/idsc/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -61,9 +61,8 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.prep.MatsimKMeansVirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.traveldata.TravelData;
 import ch.ethz.idsc.amodeus.traveldata.StaticTravelDataCreator;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
+import ch.ethz.idsc.amodeus.traveldata.TravelData;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.matsim.av.config.AVConfig;
@@ -162,7 +161,7 @@ public class StandardMATSimScenarioTest {
     public static void setUp() throws IOException {
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
     }
@@ -178,7 +177,7 @@ public class StandardMATSimScenarioTest {
         Config config = ConfigUtils.createConfig(new AVConfigGroup(), new DvrpConfigGroup());
         Scenario scenario = TestScenarioGenerator.generateWithAVLegs(config);
 
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         ScenarioOptions simOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
         LocationSpec locationSpec = simOptions.getLocationSpec();
         ReferenceFrame referenceFrame = locationSpec.referenceFrame();
@@ -269,12 +268,11 @@ public class StandardMATSimScenarioTest {
             public TravelData provideTravelData(VirtualNetwork<Link> virtualNetwork, @Named(AVModule.AV_MODE) Network network, Population population) throws Exception {
                 // Same as for the virtual network: For the LPFF dispatcher we need travel
                 // data, which we generate on the fly here.
-                ScenarioOptions scenarioOptions = new ScenarioOptions(MultiFileTools.getWorkingDirectory(), ScenarioOptionsBase.getDefault());
 
-                LPOptions lpOptions = new LPOptions(MultiFileTools.getWorkingDirectory(), LPOptionsBase.getDefault());
+                LPOptions lpOptions = new LPOptions(simOptions.getWorkingDirectory(), LPOptionsBase.getDefault());
                 lpOptions.setProperty(LPOptionsBase.LPSOLVER, "timeInvariant");
                 lpOptions.saveAndOverwriteLPOptions();
-                TravelData travelData = StaticTravelDataCreator.create(virtualNetwork, network, population, scenarioOptions.getdtTravelData(),
+                TravelData travelData = StaticTravelDataCreator.create(simOptions.getWorkingDirectory(), virtualNetwork, network, population, simOptions.getdtTravelData(),
                         (int) generatorConfig.getNumberOfVehicles(), endTime);
                 return travelData;
             }

--- a/src/test/java/ch/ethz/idsc/amodeus/prep/Preparer.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/prep/Preparer.java
@@ -22,9 +22,8 @@ import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
     /* package */ final Population population;
     /* package */ final Config config;
 
-    public Preparer() throws IOException {
+    public Preparer(File workingDirectory) throws IOException {
         // Static.setup();
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
 
         /** amodeus options */
         scenOpt = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());

--- a/src/test/java/ch/ethz/idsc/amodeus/prep/Preparer.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/prep/Preparer.java
@@ -13,7 +13,6 @@ import org.matsim.core.scenario.ScenarioUtils;
 
 import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 
 /* package */ class Preparer {
 

--- a/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
@@ -54,7 +54,7 @@ public class ScenarioPipeLineTest {
 
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 
@@ -104,7 +104,7 @@ public class ScenarioPipeLineTest {
         System.out.print("Server Test:\t");
 
         // scenario options
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
         assertEquals("config.xml", scenarioOptions.getSimulationConfigName());
         assertEquals("preparedNetwork", scenarioOptions.getPreparedNetworkName());

--- a/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
@@ -23,7 +23,6 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.testutils.TestPreparer;
 import ch.ethz.idsc.amodeus.testutils.TestServer;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.util.math.SI;
 import ch.ethz.idsc.tensor.RealScalar;

--- a/src/test/java/ch/ethz/idsc/amodeus/test/SharedRoboTaxiTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/SharedRoboTaxiTest.java
@@ -24,7 +24,6 @@ import ch.ethz.idsc.amodeus.options.ScenarioOptionsBase;
 import ch.ethz.idsc.amodeus.testutils.SharedTestServer;
 import ch.ethz.idsc.amodeus.testutils.TestPreparer;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.util.math.SI;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkGet;

--- a/src/test/java/ch/ethz/idsc/amodeus/test/SharedRoboTaxiTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/SharedRoboTaxiTest.java
@@ -52,7 +52,7 @@ public class SharedRoboTaxiTest {
 
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 
@@ -64,7 +64,7 @@ public class SharedRoboTaxiTest {
 
         // prepare travel data test
         // vNCreated =
-        VirtualNetworkGet.readDefault(testPreparer.getPreparedNetwork());
+        VirtualNetworkGet.readDefault(testPreparer.getPreparedNetwork(), new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault()));
         Map<String, Link> map = new HashMap<>();
         testPreparer.getPreparedNetwork().getLinks().entrySet().forEach(e -> map.put(e.getKey().toString(), e.getValue()));
         // vNSaved =
@@ -101,7 +101,7 @@ public class SharedRoboTaxiTest {
         System.out.print("Server Test:\t");
 
         /** scenario options */
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
         assertEquals("config.xml", scenarioOptions.getSimulationConfigName());
         assertEquals("preparedNetwork", scenarioOptions.getPreparedNetworkName());

--- a/src/test/java/ch/ethz/idsc/amodeus/testutils/SharedTestServer.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/testutils/SharedTestServer.java
@@ -118,7 +118,7 @@ public class SharedTestServer {
         controler.addOverridingModule(new AmodeusVehicleGeneratorModule());
         controler.addOverridingModule(new AmodeusVehicleToVSGeneratorModule());
         controler.addOverridingModule(new AmodeusDispatcherModule());
-        controler.addOverridingModule(new AmodeusVirtualNetworkModule());
+        controler.addOverridingModule(new AmodeusVirtualNetworkModule(scenarioOptions));
         controler.addOverridingModule(new AmodeusDatabaseModule(db));
         controler.addOverridingModule(new AbstractModule() {
             @Override

--- a/src/test/java/ch/ethz/idsc/amodeus/testutils/TestPreparer.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/testutils/TestPreparer.java
@@ -76,7 +76,8 @@ public class TestPreparer {
 
         // 4) create TravelData
         /** reading the customer requests */
-        StaticTravelData travelData = StaticTravelDataCreator.create(virtualNetwork, networkPrepared, populationPrepared, scenarioOptions.getdtTravelData(), numRt, endTime);
+        StaticTravelData travelData = StaticTravelDataCreator.create(scenarioOptions.getWorkingDirectory(), virtualNetwork, networkPrepared, populationPrepared,
+                scenarioOptions.getdtTravelData(), numRt, endTime);
         File travelDataFile = new File(scenarioOptions.getVirtualNetworkName(), scenarioOptions.getTravelDataName());
         TravelDataIO.writeStatic(travelDataFile, travelData);
 

--- a/src/test/java/ch/ethz/idsc/amodeus/testutils/TestServer.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/testutils/TestServer.java
@@ -117,7 +117,7 @@ public class TestServer {
         controler.addOverridingModule(new AmodeusVehicleGeneratorModule());
         controler.addOverridingModule(new AmodeusVehicleToVSGeneratorModule());
         controler.addOverridingModule(new AmodeusDispatcherModule());
-        controler.addOverridingModule(new AmodeusVirtualNetworkModule());
+        controler.addOverridingModule(new AmodeusVirtualNetworkModule(scenarioOptions));
         controler.addOverridingModule(new AmodeusDatabaseModule(db));
         controler.addOverridingModule(new AbstractModule() {
             @Override

--- a/src/test/java/ch/ethz/idsc/amodeus/testutils/TestUtils.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/testutils/TestUtils.java
@@ -2,11 +2,20 @@
 package ch.ethz.idsc.amodeus.testutils;
 
 import java.io.File;
+import java.io.IOException;
 
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 
 public enum TestUtils {
     ;
+
+    public static File getWorkingDirectory() {
+        try {
+            return new File("").getCanonicalFile();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 
     public static File getSuperFolder(String name) {
         File file = new File(TestUtils.class.getResource("TestUtils.class").getFile());

--- a/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN2.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN2.java
@@ -53,7 +53,7 @@ public class PopulationToolsTestVN2 {
     public static void setup() throws IOException {
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.exists());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 

--- a/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN2.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN2.java
@@ -28,7 +28,6 @@ import ch.ethz.idsc.amodeus.prep.Request;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.io.ProvideAVConfig;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;

--- a/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN3.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN3.java
@@ -27,7 +27,6 @@ import ch.ethz.idsc.amodeus.prep.Request;
 import ch.ethz.idsc.amodeus.prep.VirtualNetworkCreator;
 import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.util.io.ProvideAVConfig;
 import ch.ethz.idsc.amodeus.util.math.GlobalAssert;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;

--- a/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN3.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/traveldata/PopulationToolsTestVN3.java
@@ -52,7 +52,7 @@ public class PopulationToolsTestVN3 {
     public static void setUp() throws IOException {
         // copy scenario data into main directory
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         GlobalAssert.that(workingDirectory.exists());
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
 

--- a/src/test/java/ch/ethz/idsc/amodeus/traveldata/TravelDataTestHelper.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/traveldata/TravelDataTestHelper.java
@@ -5,21 +5,22 @@ import java.io.File;
 
 import org.matsim.api.core.v01.network.Link;
 
+import ch.ethz.idsc.amodeus.options.ScenarioOptions;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.tensor.sca.Chop;
 
 public class TravelDataTestHelper {
 
-    public static TravelDataTestHelper prepare(VirtualNetwork<Link> vNCreated, VirtualNetwork<Link> vNSaved) throws Exception {
-        return new TravelDataTestHelper(vNCreated, vNSaved);
+    public static TravelDataTestHelper prepare(VirtualNetwork<Link> vNCreated, VirtualNetwork<Link> vNSaved, ScenarioOptions scenarioOptions) throws Exception {
+        return new TravelDataTestHelper(vNCreated, vNSaved, scenarioOptions);
     }
 
     // ---
     private TravelData tDCreated;
     private TravelData tDSaved;
 
-    private TravelDataTestHelper(VirtualNetwork<Link> vNCreated, VirtualNetwork<Link> vNSaved) throws Exception {
-        tDCreated = TravelDataGet.readStatic(vNCreated);
+    private TravelDataTestHelper(VirtualNetwork<Link> vNCreated, VirtualNetwork<Link> vNSaved, ScenarioOptions scenarioOptions) throws Exception {
+        tDCreated = TravelDataGet.readStatic(vNCreated, scenarioOptions);
         tDSaved = TravelDataIO.readStatic(new File("resources/testComparisonFiles/travelData"), vNSaved);
     }
 

--- a/src/test/java/ch/ethz/idsc/amodeus/virtualnetwork/SaveLoadTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/virtualnetwork/SaveLoadTest.java
@@ -20,7 +20,6 @@ import ch.ethz.idsc.amodeus.test.TestFileHandling;
 import ch.ethz.idsc.amodeus.testutils.TestPreparer;
 import ch.ethz.idsc.amodeus.testutils.TestUtils;
 import ch.ethz.idsc.amodeus.traveldata.TravelDataTestHelper;
-import ch.ethz.idsc.amodeus.util.io.MultiFileTools;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetwork;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkGet;
 import ch.ethz.idsc.amodeus.virtualnetwork.core.VirtualNetworkIO;

--- a/src/test/java/ch/ethz/idsc/amodeus/virtualnetwork/SaveLoadTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/virtualnetwork/SaveLoadTest.java
@@ -35,17 +35,17 @@ public class SaveLoadTest {
 
     @BeforeClass
     public static void before() throws Exception {
-        File workingDirectory = MultiFileTools.getWorkingDirectory();
+        File workingDirectory = TestUtils.getWorkingDirectory();
         File scenarioDirectory = new File(TestUtils.getSuperFolder("amodeus"), "resources/testScenario");
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
         scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
         testPreparer = TestPreparer.run().on(workingDirectory);
-        vNCreated = VirtualNetworkGet.readDefault(testPreparer.getPreparedNetwork());
+        vNCreated = VirtualNetworkGet.readDefault(testPreparer.getPreparedNetwork(), scenarioOptions);
         Map<String, Link> map = new HashMap<>();
         testPreparer.getPreparedNetwork().getLinks().entrySet().forEach(e -> map.put(e.getKey().toString(), e.getValue()));
         // TODO document how to regenerate virtualNetwork test file
         vNSaved = VirtualNetworkIO.fromByte(map, new File("resources/testComparisonFiles/virtualNetwork"));
-        travelDataTestHelper = TravelDataTestHelper.prepare(vNCreated, vNSaved);
+        travelDataTestHelper = TravelDataTestHelper.prepare(vNCreated, vNSaved, scenarioOptions);
     }
 
     @Test


### PR DESCRIPTION
`ScenarioOptions` is constructed with a `workingDirectory` argument by default already, so it already carries that information. Now in a lot of spots in the code there was code like 

```
ScenarioOptions scenarioOptions = new ScenarioOptions(MultiFileUtils.getWorkingDirectory(), ...);
```

So instead of replicating this piece of code again and again (with the downside of all of the classes only being able to operate in the "working directory"). I refactored everything to depend on `ScenarioOptions` via parameter or class variable **if** it is actually used somewhere and to rely on a `workingDirectory` parameter if only the working directory is of interest. Practically, the code now looks in a way that the above line of code exists **once** in every Amodeus run script and then the `ScenarioOptions` object is passed down the function tree. This removes replication of code and also makes everything independent of a global `getWorkingDirectory`, but the directory can always be defined explicitly now.

