### PR TITLE
Update to latest stable MATSim + av

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,23 +17,23 @@
 		<dependency>
 			<groupId>ch.ethz.matsim</groupId>
 			<artifactId>av</artifactId>
-			<version>0.1.6-amodeus</version>
+			<version>0.2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.ethz.matsim</groupId>
 			<artifactId>av</artifactId>
-			<version>0.1.4</version>
+			<version>0.2.7</version>
 			<type>test-jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim</artifactId>
-			<version>0.10.0-nov17</version>
+			<version>0.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>0.10.0-nov17</version>
+			<version>0.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.ethz.idsc</groupId>
@@ -77,8 +77,12 @@
 
 	<repositories>
 		<repository>
-			<id>bintray-matsim-eth-matsim</id>
+			<id>matsim-eth</id>
 			<url>https://dl.bintray.com/matsim-eth/matsim</url>
+		</repository>
+		<repository>
+			<id>matsim-org</id>
+			<url>https://dl.bintray.com/matsim/matsim</url>
 		</repository>
 		<repository>
 			<id>tensor-mvn-repo</id>

--- a/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusModule.java
+++ b/src/main/java/ch/ethz/idsc/amodeus/matsim/mod/AmodeusModule.java
@@ -4,10 +4,12 @@ package ch.ethz.idsc.amodeus.matsim.mod;
 import java.util.Collection;
 
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimPlugin;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -19,7 +21,11 @@ import ch.ethz.matsim.av.framework.AVQSimPlugin;
 public class AmodeusModule extends AbstractModule {
     @Override
     public void install() {
-        // ---
+        /* This has been added after upgrading Amodeus' dependency to MATSim:0.10.1. In the mean time, DVRP got a new "initial travel time" which resembles better what
+         * QSim produces (since the time-step (seconds) based QSim produces travel times that are "rounded" to the next integer). This is now considered in DVRP 0.10.1,
+         * but it was not when Amodeus' unit tests had been written. Hence, to leave the unit tests intact, we add here the old FreeSpeedTravelTime. For reference, the
+         * MATSim commit, that introduced the new TravelTime implementation in DVRP is be380cfc72e1c29d840fcc6b71a4bebeb3e567c1 . */
+        addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).toInstance(new FreeSpeedTravelTime());
     }
 
     @Provides
@@ -36,7 +42,7 @@ public class AmodeusModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named(DvrpModule.DVRP_ROUTING)
+    @Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
     public Network provideAVNetwork(Network fullNetwork) {
         /* TODO MISC Here we provide the FULL network with public transit links etc.,
          * because this is how Amodeus has been set up initially. This was not a problem,

--- a/src/test/java/ch/ethz/idsc/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -29,6 +29,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.dvrp.router.DvrpRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
@@ -205,7 +206,7 @@ public class StandardMATSimScenarioTest {
 
             @Provides
             @Singleton
-            @Named(DvrpModule.DVRP_ROUTING)
+            @Named(DvrpRoutingNetworkProvider.DVRP_ROUTING)
             public Network provideAVNetwork(Network fullNetwork) {
                 /* TODO TEST Eventually, this should go directly into the AmodeusModule.
                  * - For backward compatibility AmodeusModule provides a FULL network, see there.

--- a/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
+++ b/src/test/java/ch/ethz/idsc/amodeus/test/ScenarioPipeLineTest.java
@@ -197,6 +197,9 @@ public class ScenarioPipeLineTest {
         scalarAssert.add(Quantity.of(893.155, SI.SECOND), ate.getTravelTimeAnalysis().getDrveAggrgte().Get(1));
         scalarAssert.add(Quantity.of(3670.0, SI.SECOND), ate.getTravelTimeAnalysis().getDrveAggrgte().Get(2));
 
+        /* TODO: Have a look at {AmodeusModule::install}. At some point the travel time calculation in DVRP has been improved. Unfortunately, this improvement breaks
+         * these tests. The reference numbers here should be adjusted at some point so that the fallback in {AmodeusModule::install} can be removed again.
+         * (Nevertheless, we're talking about a different in routed time of +/-1 second). /sebhoerl */
         scalarAssert.consolidate();
 
         /** presence of plot files */


### PR DESCRIPTION
- Update to latest stable MATSim 0.10.1
- Update to corresponding av package
- There have been changes in DVRP in the meantime (which gives slightly different travel times from the router +/-1 second, they are more consistent with the QSim network simulaiton now). For now I did a "backport" in the sense that still the original travel time is used, not the updated one. This way, all tests still pass. Eventually, this should be updated.