### PR TITLE
update to work with MATSim v14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+#vscode
+settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
 			<version>0.7.1</version>
 		</dependency>
 		<dependency>
-			<groupId>de.xypron.linopt</groupId>
-			<artifactId>linopt</artifactId>
-			<version>1.10</version>
-		</dependency>
-		<dependency>
 			<!-- necessary to test scenarioPreparer -->
 			<groupId>org.gnu.glpk</groupId>
 			<artifactId>glpk-java</artifactId>
@@ -83,7 +78,7 @@
 		<repository>
 			<id>XypronRelease</id>
 			<name>Xypron Release</name>
-			<url>http://rsync.xypron.de/repository</url>
+			<url>https://www.xypron.de/repository/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,6 @@
 			<name>MATSim Maven repository</name>
 			<url>https://repo.matsim.org/repository/matsim/</url>
 		</repository>
-		<repository>
-			<id>ch.sbb</id>
-			<url>https://schweizerischebundesbahnen.bintray.com/simba.mvn</url>
-		</repository>
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>amodeus</groupId>
 	<artifactId>amodeus</artifactId>
@@ -12,7 +10,7 @@
 		<skipTests>false</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<github.global.server>github</github.global.server>
-		<matsim.version>13.0-2021w08-SNAPSHOT</matsim.version>
+		<matsim.version>14.0</matsim.version>
 	</properties>
 
 	<dependencies>
@@ -46,7 +44,8 @@
 			<artifactId>linopt</artifactId>
 			<version>1.10</version>
 		</dependency>
-		<dependency><!-- necessary to test scenarioPreparer -->
+		<dependency>
+			<!-- necessary to test scenarioPreparer -->
 			<groupId>org.gnu.glpk</groupId>
 			<artifactId>glpk-java</artifactId>
 			<version>1.12.0</version>
@@ -67,6 +66,13 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.6</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.jdom/jdom2 -->
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom2</artifactId>
+			<version>2.0.6.1</version>
+		</dependency>
+
 	</dependencies>
 
 	<repositories>
@@ -86,12 +92,9 @@
 			<url>https://repo.osgeo.org/repository/release/</url>
 		</repository>
 		<repository>
-			<id>matsim-snapshot</id>
-			<url>https://oss.jfrog.org/libs-snapshot</url>
-		</repository>
-		<repository>
-			<id>matsim-release</id>
-			<url>https://dl.bintray.com/matsim/matsim</url>
+			<id>matsim</id>
+			<name>MATSim Maven repository</name>
+			<url>https://repo.matsim.org/repository/matsim/</url>
 		</repository>
 		<repository>
 			<id>ch.sbb</id>
@@ -128,8 +131,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.4</version>
-				<configuration>
-				</configuration>
+				<configuration></configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>amodeus</groupId>
 	<artifactId>amodeus</artifactId>
-	<version>2.1.1</version>
+	<version>2.2.0</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 			<version>0.8.4</version>
 		</dependency>
 		<dependency>
+			<!-- bumping to 0.7.5 breaks some tests -->
 			<groupId>de.lmu.ifi.dbs.elki</groupId>
 			<artifactId>elki</artifactId>
 			<version>0.7.1</version>
@@ -48,18 +49,19 @@
 		<dependency>
 			<groupId>io.humble</groupId>
 			<artifactId>humble-video-all</artifactId>
-			<version>0.2.1</version>
+			<version>0.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<!-- for some reason I can't bump this past 2.7. Will need to investgiate. -->
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.jdom/jdom2 -->
 		<dependency>

--- a/src/main/java/amodeus/amodeus/dispatcher/DemandSupplyBalancingDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/DemandSupplyBalancingDispatcher.java
@@ -13,7 +13,7 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.network.NetworkUtils;
@@ -30,13 +30,19 @@ import amodeus.amodeus.net.TensorCoords;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.Tensors;
 
-/** Implementation of the "demand-supply-balancing" dispatching heuristic presented in
- * Maciejewski, Michal, and Joschka Bischoff. "Large-scale microscopic simulation of taxi services."
+/**
+ * Implementation of the "demand-supply-balancing" dispatching heuristic
+ * presented in
+ * Maciejewski, Michal, and Joschka Bischoff. "Large-scale microscopic
+ * simulation of taxi services."
  * Procedia Computer Science 52 (2015): 358-364.
  * 
- * This dispatcher is not a dispatcher with rebalancing functionality, it could also be derived from
- * the UniversalDispatcher, but in order to allow extended versions to use the setRoboTaxiRebalance
- * functionality, it was extended from the abstract RebalancingDispatcher. */
+ * This dispatcher is not a dispatcher with rebalancing functionality, it could
+ * also be derived from
+ * the UniversalDispatcher, but in order to allow extended versions to use the
+ * setRoboTaxiRebalance
+ * functionality, it was extended from the abstract RebalancingDispatcher.
+ */
 public class DemandSupplyBalancingDispatcher extends RebalancingDispatcher {
 
     private final int dispatchPeriod;
@@ -47,7 +53,8 @@ public class DemandSupplyBalancingDispatcher extends RebalancingDispatcher {
     protected DemandSupplyBalancingDispatcher(Config config, AmodeusModeConfig operatorConfig, //
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, Network network, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
         dispatchPeriod = dispatcherConfig.getDispatchPeriod(10);
         double[] networkBounds = NetworkUtils.getBoundingBox(network.getNodes().values());
@@ -97,14 +104,18 @@ public class DemandSupplyBalancingDispatcher extends RebalancingDispatcher {
         }
     }
 
-    /** @param request
-     * @return {@link Coord} with {@link PassengerRequest} location */
+    /**
+     * @param request
+     * @return {@link Coord} with {@link PassengerRequest} location
+     */
     /* package */ Tensor getLocation(PassengerRequest request) {
         return TensorCoords.toTensor(request.getFromLink().getFromNode().getCoord());
     }
 
-    /** @param roboTaxi
-     * @return {@link Coord} with {@link RoboTaxi} location */
+    /**
+     * @param roboTaxi
+     * @return {@link Coord} with {@link RoboTaxi} location
+     */
     /* package */ Tensor getRoboTaxiLoc(RoboTaxi roboTaxi) {
         return TensorCoords.toTensor(roboTaxi.getDivertableLocation().getCoord());
     }
@@ -112,16 +123,16 @@ public class DemandSupplyBalancingDispatcher extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
             return new DemandSupplyBalancingDispatcher( //
                     config, operatorConfig, travelTime, //

--- a/src/main/java/amodeus/amodeus/dispatcher/DriveByDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/DriveByDispatcher.java
@@ -12,7 +12,7 @@ import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -25,8 +25,10 @@ import amodeus.amodeus.dispatcher.core.RebalancingDispatcher;
 import amodeus.amodeus.dispatcher.util.DrivebyRequestStopper;
 import amodeus.amodeus.net.MatsimAmodeusDatabase;
 
-/** Dispatcher sends vehicles to random links in the network and lets them pickup
- * any customers which are waiting along the road. */
+/**
+ * Dispatcher sends vehicles to random links in the network and lets them pickup
+ * any customers which are waiting along the road.
+ */
 public class DriveByDispatcher extends RebalancingDispatcher {
     private final List<Link> links;
     private final double rebPos = 0.99;
@@ -37,7 +39,8 @@ public class DriveByDispatcher extends RebalancingDispatcher {
     private DriveByDispatcher(Config config, AmodeusModeConfig operatorConfig, //
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, //
             Network network, MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         links = new ArrayList<>(network.getLinks().values());
         Collections.shuffle(links, randGen);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
@@ -49,7 +52,9 @@ public class DriveByDispatcher extends RebalancingDispatcher {
 
         // stop all vehicles which are driving by an open request
         total_abortTrip += DrivebyRequestStopper //
-                .stopDrivingBy(DispatcherUtils.getPassengerRequestsAtLinks(getPassengerRequests()), getDivertableRoboTaxis(), (rt, avr) -> setRoboTaxiPickup(rt, avr, Double.NaN, Double.NaN)).size();
+                .stopDrivingBy(DispatcherUtils.getPassengerRequestsAtLinks(getPassengerRequests()),
+                        getDivertableRoboTaxis(), (rt, avr) -> setRoboTaxiPickup(rt, avr, Double.NaN, Double.NaN))
+                .size();
 
         // send vehicles to travel around the city to random links (random
         // loitering)
@@ -76,17 +81,18 @@ public class DriveByDispatcher extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
-            
-            return new DriveByDispatcher(config, operatorConfig, travelTime, router, eventsManager, network, db, rebalancingStrategy);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
+
+            return new DriveByDispatcher(config, operatorConfig, travelTime, router, eventsManager, network, db,
+                    rebalancingStrategy);
         }
     }
 

--- a/src/main/java/amodeus/amodeus/dispatcher/FeedforwardFluidicRebalancingPolicy.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/FeedforwardFluidicRebalancingPolicy.java
@@ -10,7 +10,7 @@ import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -49,10 +49,13 @@ import ch.ethz.idsc.tensor.alg.Array;
 import ch.ethz.idsc.tensor.red.Total;
 import ch.ethz.idsc.tensor.sca.Floor;
 
-/** Implementation of the "Feedforward Fluidic Optimal Rebalancing Policy" presented in
+/**
+ * Implementation of the "Feedforward Fluidic Optimal Rebalancing Policy"
+ * presented in
  * Pavone, M., Smith, S.L., Frazzoli, E. and Rus, D., 2012.
  * Robotic load balancing for mobility-on-demand systems.
- * The International Journal of Robotics Research, 31(7), pp.839-854. */
+ * The International Journal of Robotics Research, 31(7), pp.839-854.
+ */
 public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
     private final AbstractVirtualNodeDest virtualNodeDest;
     private final AbstractRoboTaxiDestMatcher vehicleDestMatcher;
@@ -85,7 +88,8 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
             AbstractRoboTaxiDestMatcher abstractVehicleDestMatcher, //
             TravelData travelData, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, virtualNetwork, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, virtualNetwork, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         virtualNodeDest = abstractVirtualNodeDest;
         vehicleDestMatcher = abstractVehicleDestMatcher;
 
@@ -106,10 +110,13 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
         System.out.println(travelData.getLPName());
         System.out.println(LPTimeInvariant.class.getSimpleName());
         if (!travelData.getLPName().equals(LPTimeInvariant.class.getSimpleName())) {
-            System.err.println("Running the " + this.getClass().getSimpleName() + " requires precomputed data that must be\n"
-                    + "computed in the ScenarioPreparer. Currently the file LPOptions.properties is set to compute the feedforward\n" + "rebalancing data with: ");
+            System.err.println("Running the " + this.getClass().getSimpleName()
+                    + " requires precomputed data that must be\n"
+                    + "computed in the ScenarioPreparer. Currently the file LPOptions.properties is set to compute the feedforward\n"
+                    + "rebalancing data with: ");
             System.err.println(travelData.getLPName());
-            System.err.println("The correct setting in LPOptions.properties to run this dispatcher is:  " + LPCreator.TIMEINVARIANT.name());
+            System.err.println("The correct setting in LPOptions.properties to run this dispatcher is:  "
+                    + LPCreator.TIMEINVARIANT.name());
             throw new RuntimeException();
         }
     }
@@ -121,12 +128,18 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
         if (!started) {
             if (getRoboTaxis().size() == 0) /** return if the roboTaxis are not ready yet */
                 return;
-            /** as soon as the roboTaxis are ready, make sure to execute rebalancing and dispatching for now=0 */
+            /**
+             * as soon as the roboTaxis are ready, make sure to execute rebalancing and
+             * dispatching for now=0
+             */
             round_now = 0;
             started = true;
         }
 
-        /** Part I: permanently rebalance vehicles according to the rates output by the LP */
+        /**
+         * Part I: permanently rebalance vehicles according to the rates output by the
+         * LP
+         */
         if (round_now % rebalancingPeriod == 0 && travelData.coversTime(round_now)) {
             rebalancingRate = travelData.getAlphaRateAtTime((int) round_now);
 
@@ -137,8 +150,10 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
 
             /** ensure that not more vehicles are sent away than available */
             Map<VirtualNode<Link>, List<RoboTaxi>> availableVehicles = getVirtualNodeDivertableNotRebalancingRoboTaxis();
-            Tensor feasibleRebalanceCount = FeasibleRebalanceCreator.returnFeasibleRebalance(rebalanceCountInteger.unmodifiable(), availableVehicles);
-            total_rebalanceCount += (Integer) ((Scalar) Total.of(Tensor.of(feasibleRebalanceCount.flatten(-1)))).number();
+            Tensor feasibleRebalanceCount = FeasibleRebalanceCreator
+                    .returnFeasibleRebalance(rebalanceCountInteger.unmodifiable(), availableVehicles);
+            total_rebalanceCount += (Integer) ((Scalar) Total.of(Tensor.of(feasibleRebalanceCount.flatten(-1))))
+                    .number();
 
             /** generate routing instructions for rebalancing vehicles */
             Map<VirtualNode<Link>, List<Link>> destinationLinks = virtualNetwork.createVNodeTypeMap();
@@ -153,20 +168,28 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
                 destinationLinks.get(fromNode).addAll(rebalanceTargets);
             }
 
-            /** consistency check: rebalancing destination links must not exceed available vehicles in virtual node */
-            GlobalAssert.that(virtualNetwork.getVirtualNodes().stream().noneMatch(v -> availableVehicles.get(v).size() < destinationLinks.get(v).size()));
+            /**
+             * consistency check: rebalancing destination links must not exceed available
+             * vehicles in virtual node
+             */
+            GlobalAssert.that(virtualNetwork.getVirtualNodes().stream()
+                    .noneMatch(v -> availableVehicles.get(v).size() < destinationLinks.get(v).size()));
 
             /** send rebalancing vehicles using the setVehicleRebalance command */
             for (VirtualNode<Link> virtualNode : destinationLinks.keySet()) {
-                Map<RoboTaxi, Link> rebalanceMatching = vehicleDestMatcher.matchLink(availableVehicles.get(virtualNode), destinationLinks.get(virtualNode));
+                Map<RoboTaxi, Link> rebalanceMatching = vehicleDestMatcher.matchLink(availableVehicles.get(virtualNode),
+                        destinationLinks.get(virtualNode));
                 rebalanceMatching.keySet().forEach(v -> setRoboTaxiRebalance(v, rebalanceMatching.get(v)));
             }
 
             rebalanceCountInteger = Array.zeros(nVNodes, nVNodes);
         }
 
-        /** Part II: outside rebalancing periods, permanently assign destinations to vehicles using
-         * bipartite matching */
+        /**
+         * Part II: outside rebalancing periods, permanently assign destinations to
+         * vehicles using
+         * bipartite matching
+         */
         if (round_now % dispatchPeriod == 0)
             printVals = bipartiteMatcher.executePickup(this, getDivertableRoboTaxis(), //
                     getPassengerRequests(), distanceFunction, network);
@@ -184,24 +207,27 @@ public class FeedforwardFluidicRebalancingPolicy extends PartitionedDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
 
-            VirtualNetwork<Link> virtualNetwork = inject.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-            });
+            VirtualNetwork<Link> virtualNetwork = (VirtualNetwork<Link>) inject
+                    .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                    });
 
-            TravelData travelData = inject.getModal(TravelData.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            TravelData travelData = (TravelData) inject.getModal(TravelData.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
             AbstractVirtualNodeDest abstractVirtualNodeDest = new RandomVirtualNodeDest();
-            AbstractRoboTaxiDestMatcher abstractVehicleDestMatcher = new GlobalBipartiteMatching(EuclideanDistanceCost.INSTANCE);
-            return new FeedforwardFluidicRebalancingPolicy(config, operatorConfig, travelTime, router, eventsManager, network, virtualNetwork, //
+            AbstractRoboTaxiDestMatcher abstractVehicleDestMatcher = new GlobalBipartiteMatching(
+                    EuclideanDistanceCost.INSTANCE);
+            return new FeedforwardFluidicRebalancingPolicy(config, operatorConfig, travelTime, router, eventsManager,
+                    network, virtualNetwork, //
                     abstractVirtualNodeDest, abstractVehicleDestMatcher, travelData, db, rebalancingStrategy);
         }
     }

--- a/src/main/java/amodeus/amodeus/dispatcher/GlobalBipartiteMatchingDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/GlobalBipartiteMatchingDispatcher.java
@@ -6,7 +6,7 @@ import org.matsim.amodeus.components.AmodeusRouter;
 import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -24,13 +24,19 @@ import amodeus.amodeus.util.matsim.SafeConfig;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.Tensors;
 
-/** Dispatcher repeatedly solves a bipartite matching problem to match available vehicles and open requests.
- * The problem can either be solved using networkdistance or Euclidean distance. Currently network
+/**
+ * Dispatcher repeatedly solves a bipartite matching problem to match available
+ * vehicles and open requests.
+ * The problem can either be solved using networkdistance or Euclidean distance.
+ * Currently network
  * distance is enabled.
  * 
- * This dispatcher is not a dispatcher with rebalancing functionality, it could also be derived from
- * the UniversalDispatcher, but in order to allow extended versions to use the setRoboTaxiRebalance
- * functionality, it was extended from the abstract RebalancingDispatcher. */
+ * This dispatcher is not a dispatcher with rebalancing functionality, it could
+ * also be derived from
+ * the UniversalDispatcher, but in order to allow extended versions to use the
+ * setRoboTaxiRebalance
+ * functionality, it was extended from the abstract RebalancingDispatcher.
+ */
 public class GlobalBipartiteMatchingDispatcher extends RebalancingDispatcher {
 
     private final int dispatchPeriod;
@@ -43,7 +49,8 @@ public class GlobalBipartiteMatchingDispatcher extends RebalancingDispatcher {
             AmodeusModeConfig operatorConfig, TravelTime travelTime, //
             AmodeusRouter router, EventsManager eventsManager, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
         dispatchPeriod = dispatcherConfig.getDispatchPeriod(30);
         DistanceHeuristics distanceHeuristics = //
@@ -51,7 +58,10 @@ public class GlobalBipartiteMatchingDispatcher extends RebalancingDispatcher {
         System.out.println("Using DistanceHeuristics: " + distanceHeuristics.name());
         distanceFunction = distanceHeuristics.getDistanceFunction(network);
         this.network = network;
-        /** matching algorithm - standard is a solution to the assignment problem with the Hungarian method */
+        /**
+         * matching algorithm - standard is a solution to the assignment problem with
+         * the Hungarian method
+         */
         SafeConfig safeConfig = SafeConfig.wrap(operatorConfig.getDispatcherConfig());
         bipartiteMatcher = new ConfigurableBipartiteMatcher(network, new DistanceCost(distanceFunction), //
                 safeConfig);
@@ -76,17 +86,18 @@ public class GlobalBipartiteMatchingDispatcher extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
-            
-            return new GlobalBipartiteMatchingDispatcher(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
+
+            return new GlobalBipartiteMatchingDispatcher(network, config, operatorConfig, travelTime, router,
+                    eventsManager, db, rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/ModelFreeAdaptiveRepositioning.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/ModelFreeAdaptiveRepositioning.java
@@ -14,7 +14,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -38,9 +38,12 @@ import amodeus.amodeus.util.matsim.SafeConfig;
 import ch.ethz.idsc.tensor.Tensor;
 import ch.ethz.idsc.tensor.Tensors;
 
-/** Implementation of the "+1 method" presented in
+/**
+ * Implementation of the "+1 method" presented in
  * Ruch, C., Gächter, J., Hakenberg, J. and Frazzoli, E., 2019.
- * The +1 Method: Model-Free Adaptive Repositioning Policies for Robotic Multi-Agent Systems. */
+ * The +1 Method: Model-Free Adaptive Repositioning Policies for Robotic
+ * Multi-Agent Systems.
+ */
 public class ModelFreeAdaptiveRepositioning extends RebalancingDispatcher {
     private final Network network;
     private final BipartiteMatcher assignmentMatcher;
@@ -58,7 +61,8 @@ public class ModelFreeAdaptiveRepositioning extends RebalancingDispatcher {
     private ModelFreeAdaptiveRepositioning(Network network, Config config, AmodeusModeConfig operatorConfig, //
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         this.network = network;
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
         dispatchPeriod = dispatcherConfig.getDispatchPeriod(30);
@@ -99,13 +103,18 @@ public class ModelFreeAdaptiveRepositioning extends RebalancingDispatcher {
         if (round_now % rebalancingPeriod == 0) {
             /** step 2, perform rebalancing on last known request locations */
             Collection<Link> rebalanceLinks = getLastRebalanceLocations(getDivertableRoboTaxis().size());
-            Map<RoboTaxi, Link> rebalanceMatching = rebalanceMatcher.matchLink(getDivertableRoboTaxis(), rebalanceLinks);
+            Map<RoboTaxi, Link> rebalanceMatching = rebalanceMatcher.matchLink(getDivertableRoboTaxis(),
+                    rebalanceLinks);
             rebalanceMatching.forEach(this::setRoboTaxiRebalance);
 
-            /** stop vehicles which are still divertable and driving to have only one rebalance vehicles
-             * going to a request */
-            getDivertableRoboTaxis().stream().filter(rt -> rt.getStatus().equals(RoboTaxiStatus.REBALANCEDRIVE)).forEach(rt -> //
-            setRoboTaxiRebalance(rt, rt.getDivertableLocation()));
+            /**
+             * stop vehicles which are still divertable and driving to have only one
+             * rebalance vehicles
+             * going to a request
+             */
+            getDivertableRoboTaxis().stream().filter(rt -> rt.getStatus().equals(RoboTaxiStatus.REBALANCEDRIVE))
+                    .forEach(rt -> //
+                    setRoboTaxiRebalance(rt, rt.getDivertableLocation()));
         }
     }
 
@@ -125,16 +134,16 @@ public class ModelFreeAdaptiveRepositioning extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
-            
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
+
             return new ModelFreeAdaptiveRepositioning( //
                     network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
         }

--- a/src/main/java/amodeus/amodeus/dispatcher/NoExplicitCommunication.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/NoExplicitCommunication.java
@@ -10,7 +10,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -20,14 +20,19 @@ import amodeus.amodeus.dispatcher.core.RoboTaxi;
 import amodeus.amodeus.net.MatsimAmodeusDatabase;
 import amodeus.amodeus.net.TensorCoords;
 
-/** Arsie, Alessandro, Ketan Savla, and Emilio Frazzoli. "Efficient routing algorithms for multiple
- * vehicles with no explicit communications." IEEE Transactions on Automatic Control 54.10 (2009): 2302-2317. ,
- * Algorithm 1 "A control policy requiring no explicit communication" */
+/**
+ * Arsie, Alessandro, Ketan Savla, and Emilio Frazzoli. "Efficient routing
+ * algorithms for multiple
+ * vehicles with no explicit communications." IEEE Transactions on Automatic
+ * Control 54.10 (2009): 2302-2317. ,
+ * Algorithm 1 "A control policy requiring no explicit communication"
+ */
 public class NoExplicitCommunication extends AbstractNoExplicitCommunication {
 
     private NoExplicitCommunication(Network network, Config config, //
             AmodeusModeConfig operatorConfig, TravelTime travelTime, //
-            AmodeusRouter router, EventsManager eventsManager, MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
+            AmodeusRouter router, EventsManager eventsManager, MatsimAmodeusDatabase db,
+            RebalancingStrategy rebalancingStrategy) {
         super(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
     }
 
@@ -36,17 +41,22 @@ public class NoExplicitCommunication extends AbstractNoExplicitCommunication {
         /** 1) if D(t) not empty, move towards nearest outstanding target */
         for (RoboTaxi roboTaxi : getDivertableRoboTaxis()) {
             if (getPassengerRequests().size() > 0) {
-                PassengerRequest closest = requestMaintainer.getClosest(TensorCoords.toTensor(roboTaxi.getDivertableLocation().getCoord()));
-                /** here rebalance not pickup is chosen as in the policy, all
+                PassengerRequest closest = requestMaintainer
+                        .getClosest(TensorCoords.toTensor(roboTaxi.getDivertableLocation().getCoord()));
+                /**
+                 * here rebalance not pickup is chosen as in the policy, all
                  * agents move towards the open targets, i.e., there can be more than
-                 * one agent moving towards a target */
+                 * one agent moving towards a target
+                 */
                 if (Objects.nonNull(closest))
                     /** excessive computation is avoided if rebalancing command given only once */
                     if (!roboTaxi.getCurrentDriveDestination().equals(closest.getFromLink()))
                         setRoboTaxiRebalance(roboTaxi, closest.getFromLink());
             } else {
-                /** move towards the point minimizing the average distance to targets
-                 * serviced in the past by each agent */
+                /**
+                 * move towards the point minimizing the average distance to targets
+                 * serviced in the past by each agent
+                 */
                 Link link = weberMaintainers.get(roboTaxi).getClosestMinimizer(roboTaxi.getDivertableLocation());
                 /** excessive computation is avoided if rebalancing command given only once */
                 if (!roboTaxi.getCurrentDriveDestination().equals(link))
@@ -58,17 +68,18 @@ public class NoExplicitCommunication extends AbstractNoExplicitCommunication {
     public static class Factory implements AmodeusDispatcher.AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
-            
-            return new NoExplicitCommunication(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
+
+            return new NoExplicitCommunication(network, config, operatorConfig, travelTime, router, eventsManager, db,
+                    rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/SBNoExplicitCommunication.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/SBNoExplicitCommunication.java
@@ -11,7 +11,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -22,9 +22,13 @@ import amodeus.amodeus.dispatcher.util.VoronoiPartition;
 import amodeus.amodeus.net.MatsimAmodeusDatabase;
 import amodeus.amodeus.net.TensorCoords;
 
-/** Arsie, Alessandro, Ketan Savla, and Emilio Frazzoli. "Efficient routing algorithms for multiple
- * vehicles with no explicit communications." IEEE Transactions on Automatic Control 54.10 (2009): 2302-2317. ,
- * Algorithm 2 "A sensor based control policy" */
+/**
+ * Arsie, Alessandro, Ketan Savla, and Emilio Frazzoli. "Efficient routing
+ * algorithms for multiple
+ * vehicles with no explicit communications." IEEE Transactions on Automatic
+ * Control 54.10 (2009): 2302-2317. ,
+ * Algorithm 2 "A sensor based control policy"
+ */
 public class SBNoExplicitCommunication extends AbstractNoExplicitCommunication {
     private final VoronoiPartition<RoboTaxi> voronoiPartition;
 
@@ -46,17 +50,22 @@ public class SBNoExplicitCommunication extends AbstractNoExplicitCommunication {
         for (RoboTaxi roboTaxi : getDivertableRoboTaxis()) {
             PassengerRequest closest = requestMaintainer.getClosest( //
                     TensorCoords.toTensor(roboTaxi.getDivertableLocation().getCoord()));
-            // /** as long as the {@link RoboTaxi} has never visited any target, move towards closest request */
+            // /** as long as the {@link RoboTaxi} has never visited any target, move
+            // towards closest request */
             // if (!weberMaintainers.get(roboTaxi).visitedTargets()) {
             // if (Objects.nonNull(closest)) {
             // setRoboTaxiRebalance(roboTaxi, closest.getFromLink());
             // }
             // continue;
             // }
-            /** move towards the closest target in the Voronoi region of the {@link RoboTaxi} */
+            /**
+             * move towards the closest target in the Voronoi region of the {@link RoboTaxi}
+             */
             if (Objects.isNull(closest)) {
-                /** move towards the point minimizing the average distance to targets
-                 * serviced in the past by each agent */
+                /**
+                 * move towards the point minimizing the average distance to targets
+                 * serviced in the past by each agent
+                 */
                 Link link = weberMaintainers.get(roboTaxi).getClosestMinimizer(roboTaxi.getDivertableLocation());
                 /** excessive computation is avoided if rebalancing command given only once */
                 if (!roboTaxi.getCurrentDriveDestination().equals(link)) {
@@ -65,16 +74,20 @@ public class SBNoExplicitCommunication extends AbstractNoExplicitCommunication {
                 continue;
             }
             if (voronoiPartition.of(roboTaxi).contains(closest.getFromLink())) {
-                /** here rebalance not pickup is chosen as in the policy, all
+                /**
+                 * here rebalance not pickup is chosen as in the policy, all
                  * agents move towards the open targets, i.e., there can be more than
-                 * one agent moving towards a target */
+                 * one agent moving towards a target
+                 */
                 /** excessive computation is avoided if rebalancing command given only once */
                 if (!roboTaxi.getCurrentDriveDestination().equals(closest.getFromLink())) {
                     setRoboTaxiRebalance(roboTaxi, closest.getFromLink());
                 }
             } else {
-                /** move towards the point minimizing the average distance to targets
-                 * serviced in the past by each agent */
+                /**
+                 * move towards the point minimizing the average distance to targets
+                 * serviced in the past by each agent
+                 */
                 Link link = weberMaintainers.get(roboTaxi).getClosestMinimizer(roboTaxi.getDivertableLocation());
                 /** excessive computation is avoided if rebalancing command given only once */
                 if (!roboTaxi.getCurrentDriveDestination().equals(link)) {
@@ -91,17 +104,18 @@ public class SBNoExplicitCommunication extends AbstractNoExplicitCommunication {
     public static class Factory implements AmodeusDispatcher.AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
-            return new SBNoExplicitCommunication(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            return new SBNoExplicitCommunication(network, config, operatorConfig, travelTime, router, eventsManager, db,
+                    rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/SQMDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/SQMDispatcher.java
@@ -16,7 +16,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -34,7 +34,8 @@ import amodeus.amodeus.util.math.GlobalAssert;
 import amodeus.amodeus.virtualnetwork.core.VirtualNetwork;
 import amodeus.amodeus.virtualnetwork.core.VirtualNode;
 
-/** Implementation of the SQM algorithm (pp. 5625) of "Fundamental Performance
+/**
+ * Implementation of the SQM algorithm (pp. 5625) of "Fundamental Performance
  * Limits and Efficient Polices for Transportation-On-Demand Systems" presented
  * by M.Pavone, K.Treleaven, E.Frazzoli, 2010, 49th IEEE Conference on Decision
  * and Control, pp.5622-5629
@@ -45,7 +46,8 @@ import amodeus.amodeus.virtualnetwork.core.VirtualNode;
  * 
  * The number of vehicles and virtual nodes have to be equal.
  * 
- * @author fluric */
+ * @author fluric
+ */
 public class SQMDispatcher extends PartitionedDispatcher {
     private final MatsimAmodeusDatabase db;
     private final Map<VirtualNode<Link>, RoboTaxi> nodeToTaxi = new HashMap<>();
@@ -58,7 +60,8 @@ public class SQMDispatcher extends PartitionedDispatcher {
             TravelTime travelTime, AmodeusRouter router, //
             EventsManager eventsManager, Network network, //
             VirtualNetwork<Link> virtualNetwork, MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, virtualNetwork, db, rebalancingStrategy, RoboTaxiUsageType.SINGLEUSED);
+        super(config, operatorConfig, travelTime, router, eventsManager, virtualNetwork, db, rebalancingStrategy,
+                RoboTaxiUsageType.SINGLEUSED);
         // <- virtualNetwork is non-null here
         GlobalAssert.that(operatorConfig.getGeneratorConfig().getNumberOfVehicles() == virtualNetwork.getvNodesCount());
         this.db = db;
@@ -89,7 +92,8 @@ public class SQMDispatcher extends PartitionedDispatcher {
                 double earliestSubmission = Double.MAX_VALUE;
                 PassengerRequest earliestAvr = null;
                 for (PassengerRequest avr : unassigned_requests) {
-                    if (taxiToNode.get(taxi).getLinks().contains(avr.getFromLink()) && avr.getSubmissionTime() < earliestSubmission) {
+                    if (taxiToNode.get(taxi).getLinks().contains(avr.getFromLink())
+                            && avr.getSubmissionTime() < earliestSubmission) {
                         earliestSubmission = avr.getSubmissionTime();
                         earliestAvr = avr;
                     }
@@ -117,37 +121,43 @@ public class SQMDispatcher extends PartitionedDispatcher {
         GlobalAssert.that(nodeToTaxi.size() == nodes.size() && taxiToNode.size() == taxis.size());
     }
 
-    /** Returns the nearest {@link Link}'s to the according {@link VirtualNode}'s.
+    /**
+     * Returns the nearest {@link Link}'s to the according {@link VirtualNode}'s.
      * Using fastLinkLookup
      * 
      * @param nodes
-     *            {@link Collection} of {@link VirtualNode}'s which are the virtual
-     *            station
+     *              {@link Collection} of {@link VirtualNode}'s which are the
+     *              virtual
+     *              station
      * @return nearestLinks {@link ArrayList} of {@link Link}'s which are the
      *         closest links to corresponding virtual nodes
-     * @author fluric */
+     * @author fluric
+     */
     private List<Link> assignNodesToNearestLinks(Collection<VirtualNode<Link>> nodes) {
         return nodes.stream().map(VirtualNode::getCoord).map(TensorCoords::toCoord) // get the center coordinate
-                .mapToInt(fastLinkLookup::indexFromLocal).mapToObj(db::getOsmLink).map(osml -> osml.link) // find the closest link
+                .mapToInt(fastLinkLookup::indexFromLocal).mapToObj(db::getOsmLink).map(osml -> osml.link) // find the
+                                                                                                          // closest
+                                                                                                          // link
                 .collect(Collectors.toList());
     }
 
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
 
-            VirtualNetwork<Link> virtualNetwork = inject.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-            });
-            
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            VirtualNetwork<Link> virtualNetwork = (VirtualNetwork<Link>) inject
+                    .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                    });
+
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
             return new SQMDispatcher(config, operatorConfig, travelTime, router, eventsManager, network, //
                     virtualNetwork, db, rebalancingStrategy);

--- a/src/main/java/amodeus/amodeus/dispatcher/alonso_mora_2016/DefaultAlonsoMoraTravelFunction.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/alonso_mora_2016/DefaultAlonsoMoraTravelFunction.java
@@ -51,7 +51,8 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
 
     private final SequenceGeneratorFactory generatorFactory;
 
-    public DefaultAlonsoMoraTravelFunction(TravelTimeCalculator travelTimeCalculator, AlonsoMoraParameters parameters, IdMap<Request, AlonsoMoraRequest> requests,
+    public DefaultAlonsoMoraTravelFunction(TravelTimeCalculator travelTimeCalculator, AlonsoMoraParameters parameters,
+            IdMap<Request, AlonsoMoraRequest> requests,
             double pickupDuration, double dropoffDuration, double now) {
         this.travelTimeCalculator = travelTimeCalculator;
         this.parameters = parameters;
@@ -126,7 +127,8 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
                 initialSchedules = getRequestSchedules(initialSequence, startLink);
             }
 
-            Iterator<List<StopDirective>> generator = generatorFactory.create(startLink, existingRequests, addedRequests);
+            Iterator<List<StopDirective>> generator = generatorFactory.create(startLink, existingRequests,
+                    addedRequests);
 
             while (generator.hasNext()) {
                 List<StopDirective> proposedSequence = generator.next();
@@ -146,9 +148,11 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
                         }
                     }
 
-                    /* System.out.println(AlonsoMoraUtils.printSequence(proposedSequence));
+                    /*
+                     * System.out.println(AlonsoMoraUtils.printSequence(proposedSequence));
                      * System.out.println(cost);
-                     * System.out.println("---"); */
+                     * System.out.println("---");
+                     */
 
                     if (cost < minimumCost) {
                         minimumCost = cost;
@@ -165,15 +169,18 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         }
     }
 
-    private boolean verifyTiming(IdMap<Request, RequestSchedule> proposedSchedules, IdMap<Request, RequestSchedule> initialSchedules) {
+    private boolean verifyTiming(IdMap<Request, RequestSchedule> proposedSchedules,
+            IdMap<Request, RequestSchedule> initialSchedules) {
         for (Map.Entry<Id<Request>, RequestSchedule> entry : proposedSchedules.entrySet()) {
             RequestSchedule proposedSchedule = entry.getValue();
             RequestSchedule initialSchedule = initialSchedules.get(entry.getKey());
 
             if (initialSchedule != null && parameters.useSoftConstraintsAfterAssignment) {
                 // The request is already assigned to the vehicle. If the vehicle is delayed
-                // (due to congestion) we now might completely exclude the request-vehicle combination
-                // from the tree, which may not be ideal. If the option is actived in the parameters,
+                // (due to congestion) we now might completely exclude the request-vehicle
+                // combination
+                // from the tree, which may not be ideal. If the option is actived in the
+                // parameters,
                 // we, therefore, only make sure that no *additional* delay due to scheduling is
                 // introduced (that means normally new requests can only be appended, but not
                 // inserted before the already delayed request).
@@ -208,7 +215,8 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         IdMap<Request, RequestSchedule> schedules = new IdMap<>(Request.class);
 
         for (StopDirective stop : directives) {
-            RequestSchedule schedule = schedules.computeIfAbsent(stop.getRequest().getId(), id -> new RequestSchedule());
+            RequestSchedule schedule = schedules.computeIfAbsent(stop.getRequest().getId(),
+                    id -> new RequestSchedule());
 
             currentTime += travelTimeCalculator.getTravelTime(currentTime, currentLink, Directive.getLink(stop));
             currentLink = Directive.getLink(stop);
@@ -225,7 +233,8 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         return schedules;
     }
 
-    // TODO: This is called twice. We can also create a map that is relevant the specific problem sequence and save time for the lookup.
+    // TODO: This is called twice. We can also create a map that is relevant the
+    // specific problem sequence and save time for the lookup.
     private AlonsoMoraRequest getRequest(Id<Request> requestId) {
         return Objects.requireNonNull(requests.get(requestId));
     }
@@ -277,8 +286,11 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
 
         AlonsoMoraParameters parameters = new AlonsoMoraParameters();
 
-        // AlonsoMoraTravelFunction travelFunction = new DefaultAlonsoMoraTravelFunction(travelTimeCalculator, parameters, requests, 60.0, 60.0, 0.0);
-        AlonsoMoraTravelFunction travelFunction = new DefaultTravelFunction(parameters, 0.0, travelTimeCalculator, requests, 60.0, 60.0, Collections.emptySet());
+        // AlonsoMoraTravelFunction travelFunction = new
+        // DefaultAlonsoMoraTravelFunction(travelTimeCalculator, parameters, requests,
+        // 60.0, 60.0, 0.0);
+        AlonsoMoraTravelFunction travelFunction = new DefaultTravelFunction(parameters, 0.0, travelTimeCalculator,
+                requests, 60.0, 60.0, Collections.emptySet());
 
         {
             Optional<Result> result = travelFunction.calculate(amRequest1, amRequest2);
@@ -316,7 +328,8 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         requests.put(amRequest3.getRequest().getId(), amRequest3);
 
         RequestVehicleGraphBuilder rvBuilder = new RequestVehicleGraphBuilder(travelFunction);
-        RequestVehicleGraph rvGraph = rvBuilder.build(0.0, Arrays.asList(vehicle, vehicle2), Arrays.asList(amRequest1, amRequest2, amRequest3));
+        RequestVehicleGraph rvGraph = rvBuilder.build(0.0, Arrays.asList(vehicle, vehicle2),
+                Arrays.asList(amRequest1, amRequest2, amRequest3));
 
         AlonsoMoraUtils.printRequestVehicleGraph(rvGraph);
 
@@ -329,13 +342,15 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         Collection<TripVehicleEdge> edges = ilpSolver.solve(rtvGraph, rvGraph);
 
         for (TripVehicleEdge edge : edges) {
-            System.out.println(rtvGraph.getVehicles().get(edge.getVehicleIndex()).getId() + ": " + AlonsoMoraUtils.printSequence(edge.getSequence()));
+            System.out.println(rtvGraph.getVehicles().get(edge.getVehicleIndex()).getId() + ": "
+                    + AlonsoMoraUtils.printSequence(edge.getSequence()));
         }
 
         // REBALANCING
 
         RebalancingSolver rebalancingSolver = new RebalancingSolver(travelTimeCalculator, 0.0);
-        Map<AlonsoMoraVehicle, Link> destinations = rebalancingSolver.solve(Arrays.asList(vehicle, vehicle2), Arrays.asList(link1, link2, link5));
+        Map<AlonsoMoraVehicle, Link> destinations = rebalancingSolver.solve(Arrays.asList(vehicle, vehicle2),
+                Arrays.asList(link1, link2, link5));
 
         for (Map.Entry<AlonsoMoraVehicle, Link> entry : destinations.entrySet()) {
             System.out.println(entry.getKey().getId() + " -> " + entry.getValue().getId());
@@ -467,6 +482,12 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
             return 0;
         }
 
+        @Override
+        public double getCapacityPeriod() {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
     }
 
     static public class MockTravelTimeCalculator implements TravelTimeCalculator {
@@ -489,7 +510,7 @@ public class DefaultAlonsoMoraTravelFunction implements AlonsoMoraTravelFunction
         @Override
         public void clear() {
             // TODO Auto-generated method stub
-            
+
         }
     }
 

--- a/src/main/java/amodeus/amodeus/dispatcher/alonso_mora_2016/routing/EuclideanRouteGenerator.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/alonso_mora_2016/routing/EuclideanRouteGenerator.java
@@ -28,7 +28,8 @@ public class EuclideanRouteGenerator implements RouteGenerator {
     private final boolean failEarly;
     private boolean expanded = true;
 
-    public EuclideanRouteGenerator(boolean failEarly, Link startLink, List<Link> locations, double now, int initialPassengers) {
+    public EuclideanRouteGenerator(boolean failEarly, Link startLink, List<Link> locations, double now,
+            int initialPassengers) {
         this.startLink = startLink;
 
         this.numberOfDirectives = locations.size();
@@ -46,7 +47,8 @@ public class EuclideanRouteGenerator implements RouteGenerator {
 
     @Override
     public PartialSolution next() {
-        Link originLink = partial.indices.size() > 0 ? locations.get(partial.indices.get(partial.indices.size() - 1)) : startLink;
+        Link originLink = partial.indices.size() > 0 ? locations.get(partial.indices.get(partial.indices.size() - 1))
+                : startLink;
 
         double minimumDistance = Double.POSITIVE_INFINITY;
         int minimumDistanceIndex = -1;
@@ -72,7 +74,8 @@ public class EuclideanRouteGenerator implements RouteGenerator {
 
         expanded = false;
 
-        return new PartialSolution(partial.indices, minimumDistanceIndex, partial.time, partial.cost, partial.passengers);
+        return new PartialSolution(partial.indices, minimumDistanceIndex, partial.time, partial.cost,
+                partial.passengers);
     }
 
     @Override
@@ -249,6 +252,12 @@ public class EuclideanRouteGenerator implements RouteGenerator {
 
         @Override
         public double getFlowCapacityPerSec(double time) {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public double getCapacityPeriod() {
             // TODO Auto-generated method stub
             return 0;
         }

--- a/src/main/java/amodeus/amodeus/dispatcher/core/schedule/FutureVrpPathWithTravelData.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/core/schedule/FutureVrpPathWithTravelData.java
@@ -20,7 +20,8 @@ public class FutureVrpPathWithTravelData implements VrpPathWithTravelData {
     private final Future<Path> pathFuture;
     private final TravelTime travelTime;
 
-    public FutureVrpPathWithTravelData(double departureTime, double estimatedArrivalTime, Link fromLink, Link toLink, Future<Path> pathFuture, TravelTime travelTime) {
+    public FutureVrpPathWithTravelData(double departureTime, double estimatedArrivalTime, Link fromLink, Link toLink,
+            Future<Path> pathFuture, TravelTime travelTime) {
         this.fromLink = fromLink;
         this.toLink = toLink;
         this.departureTime = departureTime;
@@ -98,5 +99,11 @@ public class FutureVrpPathWithTravelData implements VrpPathWithTravelData {
         } else {
             return delegate.getArrivalTime();
         }
+    }
+
+    @Override
+    public VrpPathWithTravelData withDepartureTime(double timeShift) {
+        // TODO Auto-generated method stub
+        return null;
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/core/schedule/FutureVrpPathWithTravelData.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/core/schedule/FutureVrpPathWithTravelData.java
@@ -103,7 +103,6 @@ public class FutureVrpPathWithTravelData implements VrpPathWithTravelData {
 
     @Override
     public VrpPathWithTravelData withDepartureTime(double timeShift) {
-        // TODO Auto-generated method stub
-        return null;
+        return delegate;
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/shared/basic/NorthPoleSharedDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/shared/basic/NorthPoleSharedDispatcher.java
@@ -15,7 +15,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.util.TravelTime;
@@ -29,12 +29,19 @@ import amodeus.amodeus.dispatcher.shared.Compatibility;
 import amodeus.amodeus.net.MatsimAmodeusDatabase;
 import amodeus.amodeus.util.math.GlobalAssert;
 
-/** this is a demo of functionality for the shared dispatchers (> 1 person in {@link RoboTaxi}
+/**
+ * this is a demo of functionality for the shared dispatchers (> 1 person in
+ * {@link RoboTaxi}
  * 
- * whenever 4 {@link PassengerRequest}s are open, a {@link RoboTaxi} is assigned to pickup all of them,
- * it first picks up passengers 1,2,3,4 and then starts to bring passengers 1,2,3 to their destinations.
- * Passenger 4 is less lucky as the {@link RoboTaxi} first visits the city's North pole (northern most link)
- * before passenger 4 is finally dropped of and the procedure starts from beginning. */
+ * whenever 4 {@link PassengerRequest}s are open, a {@link RoboTaxi} is assigned
+ * to pickup all of them,
+ * it first picks up passengers 1,2,3,4 and then starts to bring passengers
+ * 1,2,3 to their destinations.
+ * Passenger 4 is less lucky as the {@link RoboTaxi} first visits the city's
+ * North pole (northern most link)
+ * before passenger 4 is finally dropped of and the procedure starts from
+ * beginning.
+ */
 public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
     private final int dispatchPeriod;
     private final int rebalancePeriod;
@@ -46,7 +53,8 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
             Config config, AmodeusModeConfig operatorConfig, //
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SHARED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SHARED);
         this.cityNorthPole = getNorthPole(network);
         this.equatorLinks = getEquator(network);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
@@ -61,7 +69,8 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
 
         if (round_now % dispatchPeriod == 0) {
             /** assignment of {@link RoboTaxi}s */
-            // System.err.println("DIVERTABLE TAXIS DISPATCH " + getDivertableUnassignedRoboTaxis().size());
+            // System.err.println("DIVERTABLE TAXIS DISPATCH " +
+            // getDivertableUnassignedRoboTaxis().size());
             for (RoboTaxi sharedRoboTaxi : getDivertableUnassignedRoboTaxis()) {
                 List<PassengerRequest> unassignedRequests = new ArrayList<>(getUnassignedRequests());
                 // System.err.println("UNASSIGNED REQUESTS " + unassignedRequests.size());
@@ -87,7 +96,10 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
                     sharedRoboTaxi.moveToPrevious(sharedAVCourse3);
                     sharedRoboTaxi.moveToPrevious(sharedAVCourse3);
 
-                    /** add pickup for request 4 and reorder the menu based on a list of Shared Courses */
+                    /**
+                     * add pickup for request 4 and reorder the menu based on a list of Shared
+                     * Courses
+                     */
                     List<Directive> courses = new ArrayList<>(sharedRoboTaxi.getUnmodifiableViewOfCourses());
                     courses.add(3, Directive.pickup(fourthRequest));
                     courses.add(Directive.dropoff(fourthRequest));
@@ -101,7 +113,8 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
 
                     /** check consistency and end */
                     GlobalAssert
-                            .that(Compatibility.of(sharedRoboTaxi.getUnmodifiableViewOfCourses()).forCapacity(sharedRoboTaxi.getScheduleManager(), sharedRoboTaxi.getCapacity()));
+                            .that(Compatibility.of(sharedRoboTaxi.getUnmodifiableViewOfCourses())
+                                    .forCapacity(sharedRoboTaxi.getScheduleManager(), sharedRoboTaxi.getCapacity()));
                 } else {
                     break;
                 }
@@ -110,7 +123,8 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
 
         /** dispatching of available {@link RoboTaxi}s to the equator */
         if (round_now % rebalancePeriod == 0) {
-            // System.err.println("DIVERTABLE TAXIS REBALANCE " + getDivertableUnassignedRoboTaxis().size());
+            // System.err.println("DIVERTABLE TAXIS REBALANCE " +
+            // getDivertableUnassignedRoboTaxis().size());
             /** relocation of empty {@link RoboTaxi}s to a random link on the equator */
             for (RoboTaxi roboTaxi : getDivertableUnassignedRoboTaxis()) {
                 Link rebalanceLink = equatorLinks.get(randGen.nextInt(equatorLinks.size()));
@@ -119,18 +133,26 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
         }
     }
 
-    /** @param network
-     * @return northern most {@link Link} in the {@link Network} */
+    /**
+     * @param network
+     * @return northern most {@link Link} in the {@link Network}
+     */
     private static Link getNorthPole(Network network) {
         return network.getLinks().values().stream().max(Comparator.comparingDouble(l -> l.getCoord().getY())).get();
     }
 
-    /** @param network
-     * @return all {@link Link}s crossing the equator of the city {@link Network} , starting
-     *         with links on the equator, if no links found, the search radius is increased by 1 m */
+    /**
+     * @param network
+     * @return all {@link Link}s crossing the equator of the city {@link Network} ,
+     *         starting
+     *         with links on the equator, if no links found, the search radius is
+     *         increased by 1 m
+     */
     private static List<Link> getEquator(Network network) {
-        double northX = network.getLinks().values().stream().map(Link::getCoord).map(Coord::getY).max(Double::compare).get();
-        double southX = network.getLinks().values().stream().map(Link::getCoord).map(Coord::getY).min(Double::compare).get();
+        double northX = network.getLinks().values().stream().map(Link::getCoord).map(Coord::getY).max(Double::compare)
+                .get();
+        double southX = network.getLinks().values().stream().map(Link::getCoord).map(Coord::getY).min(Double::compare)
+                .get();
         double equator = southX + (northX - southX) / 2;
 
         List<Link> equatorLinks = new ArrayList<>();
@@ -152,18 +174,19 @@ public class NorthPoleSharedDispatcher extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
 
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
-            return new NorthPoleSharedDispatcher(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            return new NorthPoleSharedDispatcher(network, config, operatorConfig, travelTime, router, eventsManager, db,
+                    rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/shared/fifs/DynamicRideSharingStrategy.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/shared/fifs/DynamicRideSharingStrategy.java
@@ -14,7 +14,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.FastAStarLandmarksFactory;
@@ -33,45 +33,66 @@ import amodeus.amodeus.routing.TimeDistanceProperty;
 import amodeus.amodeus.util.math.GlobalAssert;
 import amodeus.amodeus.util.matsim.SafeConfig;
 
-/** Implementation of the ride sharing strategy used ind:
- * Fagnant, D. J., & Kockelman, K. M. (2015). Dynamic ride-sharing and optimal fleet sizing for a
+/**
+ * Implementation of the ride sharing strategy used ind:
+ * Fagnant, D. J., & Kockelman, K. M. (2015). Dynamic ride-sharing and optimal
+ * fleet sizing for a
  * system of shared autonomous vehicles (No. 15-1962).
  * 
- * The strategy goes through the Requests in the order of the submission time. For each request it
- * is first checked if a valid ride sharing possibility is present within a radius of 5 min (MAXWAITTIME).
- * If that is not the cse it is checked if another vehicle is available within 5 minutes which is currently
- * without designates requests. If this is also not possible then the vehicle is put on a wait list which
+ * The strategy goes through the Requests in the order of the submission time.
+ * For each request it
+ * is first checked if a valid ride sharing possibility is present within a
+ * radius of 5 min (MAXWAITTIME).
+ * If that is not the cse it is checked if another vehicle is available within 5
+ * minutes which is currently
+ * without designates requests. If this is also not possible then the vehicle is
+ * put on a wait list which
  * increases the search radius in the next dispatching step.
  * 
  * Ride Sharing is considered valid if 5 constraints are fulfilled:
- * 1. Current passengers’ trip duration increases ≤ 20% (total trip duration with ride-sharing vs. without ride-sharing);
+ * 1. Current passengers’ trip duration increases ≤ 20% (total trip duration
+ * with ride-sharing vs. without ride-sharing);
  * 2. Current passengers’ remaining trip time increases ≤ 40%;
- * 3. New traveler’s total trip time increase grows by ≤ Max(20% total trip without ride-sharing, or 3 minutes);
+ * 3. New traveler’s total trip time increase grows by ≤ Max(20% total trip
+ * without ride-sharing, or 3 minutes);
  * 4. New travelers will be picked up at least within the next 5 minutes;
  * 5. Total planned trip time to serve all passengers ≤ remaining time to serve
- * the current trips + time to serve the new trip + drop-off time, if not pooled. */
+ * the current trips + time to serve the new trip + drop-off time, if not
+ * pooled.
+ */
 public class DynamicRideSharingStrategy extends RebalancingDispatcher {
 
     /** general Dispatcher Settings */
     private final int dispatchPeriod; // [s]
 
-    /** unassigned Robo Taxis in the Scenario sorted by its coordinates in a Tree Structure */
+    /**
+     * unassigned Robo Taxis in the Scenario sorted by its coordinates in a Tree
+     * Structure
+     */
     private final RoboTaxiHandler roboTaxiHandler;
 
     /** Normal: 300 [s], Time after which a request is put on to the wait list */
     private static final double WAITLISTTIME = 300.0;
     /** Normal is 600 [s] */
     private static final double MAXWAITTIME = 600.0;
-    /** Unit: [s] The extreme wait list is used here as in AMoDeus requests should not be rejected.
-     * This list guarantees for requests waiting for more than MaxWaitTime that a taxi can be found */
+    /**
+     * Unit: [s] The extreme wait list is used here as in AMoDeus requests should
+     * not be rejected.
+     * This list guarantees for requests waiting for more than MaxWaitTime that a
+     * taxi can be found
+     */
     private static final double EXTREEMWAITTIME = 3600.0 * 24;
 
-    /** Maintains All the Information about the Requests. keeps track of Assignements, Pickups, ... */
+    /**
+     * Maintains All the Information about the Requests. keeps track of
+     * Assignements, Pickups, ...
+     */
     private final RequestHandler requestHandler = new RequestHandler(MAXWAITTIME, WAITLISTTIME, EXTREEMWAITTIME);
 
     /** Rebalancing Class to make use of a Grid Rebalancing. And its Parameters */
     private final BlockRebalancing rebalancing;
-    private static final double BINSIZETRAVELDEMAND = 3600.0; // Assumption made for the Request records required for rebalancing
+    private static final double BINSIZETRAVELDEMAND = 3600.0; // Assumption made for the Request records required for
+                                                              // rebalancing
     private static final double REBALANCINGGRIDDISTANCE = 3218.69; // 2.0 miles in [m]
     private static final int MINNUMBERROBOTAXISINBLOCKTOREBALANCE = 5;
 
@@ -90,7 +111,8 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
             Config config, AmodeusModeConfig operatorConfig, //
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SHARED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SHARED);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
         dispatchPeriod = dispatcherConfig.getDispatchPeriod(300);
 
@@ -98,7 +120,9 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
         double maxWaitTime = safeConfig.getInteger(MAXWAITTIMEID, 300); // normal is 300
         double maxDriveTimeIncrease = safeConfig.getDouble(MAXDRIVETIMEINCREASEID, 1.2); // normal is 1.2
         double maxRemainingTimeIncrease = safeConfig.getDouble(MAXREMAININGTIMEINCREASEID, 1.4); // normal is 1.4
-        double newTravelTimeIncreaseAllowed = safeConfig.getInteger(MAXABSOLUTETRAVELTIMEINCREASEID, 180); // normal is 180 (=3min);
+        double newTravelTimeIncreaseAllowed = safeConfig.getInteger(MAXABSOLUTETRAVELTIMEINCREASEID, 180); // normal is
+                                                                                                           // 180
+                                                                                                           // (=3min);
 
         roboTaxiHandler = new RoboTaxiHandler(network);
 
@@ -106,7 +130,8 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
         LeastCostPathCalculator calculator = EasyMinTimePathCalculator.prepPathCalculator(network, factory);
         timeDb = new CachedNetworkTimeDistance(calculator, MAXLAGTRAVELTIMECALCULATION, TimeDistanceProperty.INSTANCE);
 
-        rebalancing = new BlockRebalancing(network, timeDb, MINNUMBERROBOTAXISINBLOCKTOREBALANCE, BINSIZETRAVELDEMAND, dispatchPeriod, REBALANCINGGRIDDISTANCE);
+        rebalancing = new BlockRebalancing(network, timeDb, MINNUMBERROBOTAXISINBLOCKTOREBALANCE, BINSIZETRAVELDEMAND,
+                dispatchPeriod, REBALANCINGGRIDDISTANCE);
 
         routeValidation = new RouteValidation(maxWaitTime, maxDriveTimeIncrease, maxRemainingTimeIncrease, //
                 dropoffDurationPerStop, pickupDurationPerStop, newTravelTimeIncreaseAllowed);
@@ -125,41 +150,54 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
 
             /** calculate Rebalance before (!) dispatching */
             Set<Link> lastHourRequests = requestHandler.getRequestLinksLastHour();
-            RebalancingDirectives rebalanceDirectives = rebalancing.getRebalancingDirectives(round_now, lastHourRequests, requestHandler.getCopyOfUnassignedPassengerRequests(),
+            RebalancingDirectives rebalanceDirectives = rebalancing.getRebalancingDirectives(round_now,
+                    lastHourRequests, requestHandler.getCopyOfUnassignedPassengerRequests(),
                     roboTaxiHandler.getUnassignedRoboTaxis());
 
-            /** for all AV Requests in the order of their submision, try to find the closest
-             * vehicle and assign */
+            /**
+             * for all AV Requests in the order of their submision, try to find the closest
+             * vehicle and assign
+             */
             for (PassengerRequest avRequest : requestHandler.getInOrderOffSubmissionTime()) {
                 Set<RoboTaxi> robotaxisWithMenu = getRoboTaxis().stream()//
                         .filter(StaticHelper::plansPickupsOrDropoffs)//
                         .collect(Collectors.toSet());
 
                 /** THIS IS WHERE WE CALCULATE THE SHARING POSSIBILITIES */
-                Optional<Entry<RoboTaxi, List<Directive>>> rideSharingRoboTaxi = routeValidation.getClosestValidSharingRoboTaxi(robotaxisWithMenu, avRequest, now, timeDb, //
-                        requestHandler, roboTaxiHandler);
+                Optional<Entry<RoboTaxi, List<Directive>>> rideSharingRoboTaxi = routeValidation
+                        .getClosestValidSharingRoboTaxi(robotaxisWithMenu, avRequest, now, timeDb, //
+                                requestHandler, roboTaxiHandler);
 
                 if (rideSharingRoboTaxi.isPresent()) {
                     /** in Case we have a sharing possibility we assign */
                     RoboTaxi roboTaxi = rideSharingRoboTaxi.get().getKey();
-                    GlobalAssert.that(routeValidation.menuFulfillsConstraints(roboTaxi, rideSharingRoboTaxi.get().getValue(), avRequest, now, timeDb, requestHandler));
+                    GlobalAssert.that(routeValidation.menuFulfillsConstraints(roboTaxi,
+                            rideSharingRoboTaxi.get().getValue(), avRequest, now, timeDb, requestHandler));
                     addSharedRoboTaxiPickup(roboTaxi, avRequest, Double.NaN, Double.NaN);
                     requestHandler.removeFromUnasignedRequests(avRequest);
                     rebalanceDirectives.removefromDirectives(roboTaxi);
                     roboTaxi.updateMenu(rideSharingRoboTaxi.get().getValue());
 
                 } else {
-                    /** in Case No sharing possibility is present, try to find a close enough vehicle */
-                    Optional<RoboTaxi> emptyRoboTaxi = RoboTaxiUtilsFagnant.getClosestUnassignedRoboTaxiWithinMaxTime(roboTaxiHandler, avRequest,
+                    /**
+                     * in Case No sharing possibility is present, try to find a close enough vehicle
+                     */
+                    Optional<RoboTaxi> emptyRoboTaxi = RoboTaxiUtilsFagnant.getClosestUnassignedRoboTaxiWithinMaxTime(
+                            roboTaxiHandler, avRequest,
                             requestHandler.calculateWaitTime(avRequest), now, timeDb);
                     if (emptyRoboTaxi.isPresent()) {
                         /** In case we have a close vehicle which is free lets assign it */
-                        addSharedRoboTaxiPickup(emptyRoboTaxi.get(), avRequest, Double.NaN, Double.NaN); // give directive
+                        addSharedRoboTaxiPickup(emptyRoboTaxi.get(), avRequest, Double.NaN, Double.NaN); // give
+                                                                                                         // directive
                         roboTaxiHandler.assign(emptyRoboTaxi.get()); // the assigned RoboTaxi is not unassigned anymore
-                        rebalanceDirectives.removefromDirectives(emptyRoboTaxi.get()); // this taxi can not be rebalanced anymore
+                        rebalanceDirectives.removefromDirectives(emptyRoboTaxi.get()); // this taxi can not be
+                                                                                       // rebalanced anymore
                         requestHandler.removeFromUnasignedRequests(avRequest); // the request is not unassigned anymore
                     } else {
-                        /** Assignement was not possible as no Taxi was able to fulfill the constraints -> wait list! */
+                        /**
+                         * Assignement was not possible as no Taxi was able to fulfill the constraints
+                         * -> wait list!
+                         */
                         if (!requestHandler.isOnWaitList(avRequest))
                             requestHandler.addToWaitList(avRequest);
                         else // and if it was already on the wait list put it to the extreme wait list
@@ -175,8 +213,10 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
                 setRoboTaxiRebalance(entry.getKey(), entry.getValue());
             }
 
-            /** For all robotaxis which were on rebalance and did not receive a new directive
-             * stop on current link */
+            /**
+             * For all robotaxis which were on rebalance and did not receive a new directive
+             * stop on current link
+             */
             getRebalancingRoboTaxis().stream() //
                     .filter(rt -> !rebalanceDirectives.getDirectives().containsKey(rt)) //
                     .forEach(rt -> setRoboTaxiRebalance(rt, rt.getDivertableLocation()));
@@ -187,18 +227,19 @@ public class DynamicRideSharingStrategy extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
 
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
-            return new DynamicRideSharingStrategy(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            return new DynamicRideSharingStrategy(network, config, operatorConfig, travelTime, router, eventsManager,
+                    db, rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/dispatcher/shared/highcap/HighCapacityDispatcher.java
+++ b/src/main/java/amodeus/amodeus/dispatcher/shared/highcap/HighCapacityDispatcher.java
@@ -20,7 +20,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.router.FastAStarLandmarksFactory;
@@ -35,11 +35,15 @@ import amodeus.amodeus.dispatcher.core.schedule.directives.Directive;
 import amodeus.amodeus.net.MatsimAmodeusDatabase;
 import amodeus.amodeus.routing.EasyMinTimePathCalculator;
 
-/** High-Capacity Algorithm from Alonso-Mora, Javier, et al. "On-demand high-capacity ride-sharing via dynamic trip-vehicle assignment."
+/**
+ * High-Capacity Algorithm from Alonso-Mora, Javier, et al. "On-demand
+ * high-capacity ride-sharing via dynamic trip-vehicle assignment."
  * Proceedings of the National Academy of Sciences 114.3 (2017): 462-467.
  * 
- * at each time dispatcher is called, for each vehicle, all possible trips (adding additional open request to the vehicle) is explored
- * and then ILP is called to choose the optimal assignment. */
+ * at each time dispatcher is called, for each vehicle, all possible trips
+ * (adding additional open request to the vehicle) is explored
+ * and then ILP is called to choose the optimal assignment.
+ */
 public class HighCapacityDispatcher extends RebalancingDispatcher {
     private final Logger logger = Logger.getLogger(HighCapacityDispatcher.class);
 
@@ -70,11 +74,13 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
     private final CheckingUpdateMenuOrNot checkingUpdateMenuOrNot;
 
     /** other objects that are needed in each dispatching/re-balance period */
-    private List<TripWithVehicle> lastAssignment = new ArrayList<>(); // this is needed for latest pick up time modification
+    private List<TripWithVehicle> lastAssignment = new ArrayList<>(); // this is needed for latest pick up time
+                                                                      // modification
     private Set<PassengerRequest> requestMatchedLastStep = new HashSet<>();
 
     private Set<PassengerRequest> requestPool = new HashSet<>();
-    private Set<PassengerRequest> lastRequestPool = new HashSet<>(); // this is used by RV and RTV generator to speed up the process
+    private Set<PassengerRequest> lastRequestPool = new HashSet<>(); // this is used by RV and RTV generator to speed up
+                                                                     // the process
     private Set<PassengerRequest> overduedRequests = new HashSet<>();
 
     private Map<PassengerRequest, RequestKeyInfo> requestKeyInfoMap = new HashMap<>();
@@ -87,9 +93,11 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
             TravelTime travelTime, AmodeusRouter router, EventsManager eventsManager, //
             MatsimAmodeusDatabase db, RebalancingStrategy rebalancingStrategy) {
 
-        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy, RoboTaxiUsageType.SHARED);
+        super(config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy,
+                RoboTaxiUsageType.SHARED);
         DispatcherConfigWrapper dispatcherConfig = DispatcherConfigWrapper.wrap(operatorConfig.getDispatcherConfig());
-        dispatchPeriod = dispatcherConfig.getDispatchPeriod(30); // if want to change value, change in av file, here only for backup
+        dispatchPeriod = dispatcherConfig.getDispatchPeriod(30); // if want to change value, change in av file, here
+                                                                 // only for backup
         rebalancePeriod = dispatcherConfig.getRebalancingPeriod(60); // same as above
         capacityOfTaxi = operatorConfig.getGeneratorConfig().getCapacity();
 
@@ -107,11 +115,13 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
         constantMaximumDelay = dispatcherConfig.getDouble("constantMaximumDelay", Double.NaN);
 
         if (Double.isNaN(constantMaximumWaitTime)) {
-            logger.warn("No constantMaximumWaitTime set for HighCapacityDispatcher -> Using MATSIm provided value (default 300 in Amodeus without DRT).");
+            logger.warn(
+                    "No constantMaximumWaitTime set for HighCapacityDispatcher -> Using MATSIm provided value (default 300 in Amodeus without DRT).");
         }
 
         if (Double.isNaN(constantMaximumDelay)) {
-            logger.warn("No constantMaximumDelay set for HighCapacityDispatcher -> Using MATSIm provided value (default 600 in Amodeus without DRT).");
+            logger.warn(
+                    "No constantMaximumDelay set for HighCapacityDispatcher -> Using MATSIm provided value (default 600 in Amodeus without DRT).");
         }
     }
 
@@ -154,34 +164,51 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
             // remove request that is no longer open in the map
             RequestTracker.removeClosedRequest(requestPool, getPassengerRequests());
             // remove request that deadline for pick up has passed
-            overduedRequests = RequestTracker.removeOverduedRequest(requestPool, requestKeyInfoMap, now, requestMatchedLastStep);
+            overduedRequests = RequestTracker.removeOverduedRequest(requestPool, requestKeyInfoMap, now,
+                    requestMatchedLastStep);
             // put new open requests in requestKeyInfoMap (if size limit is not reached)
             for (PassengerRequest avRequest : getPassengerRequests()) {
                 if (requestPool.size() < sizeLimit && !overduedRequests.contains(avRequest))
                     requestPool.add(avRequest);
-                requestKeyInfoMap.computeIfAbsent(avRequest, avr -> new RequestKeyInfo(avr, getMaximumWaitTime(avr), getMaximumTravelTime(avr, ttc)));
+                requestKeyInfoMap.computeIfAbsent(avRequest,
+                        avr -> new RequestKeyInfo(avr, getMaximumWaitTime(avr), getMaximumTravelTime(avr, ttc)));
             }
             // modify the request key info (submission time and pickup deadline)
             requestKeyInfoMap.forEach(((avRequest, requestKeyInfo) -> {
-                requestKeyInfo.modifySubmissionTime(now, getMaximumWaitTime(avRequest), avRequest, overduedRequests); // see notes inside
-                requestKeyInfo.modifyDeadlinePickUp(lastAssignment, avRequest, getMaximumWaitTime(avRequest)); // according to paper
+                requestKeyInfo.modifySubmissionTime(now, getMaximumWaitTime(avRequest), avRequest, overduedRequests); // see
+                                                                                                                      // notes
+                                                                                                                      // inside
+                requestKeyInfo.modifyDeadlinePickUp(lastAssignment, avRequest, getMaximumWaitTime(avRequest)); // according
+                                                                                                               // to
+                                                                                                               // paper
             }));
 
-            Set<PassengerRequest> newAddedValidRequests = RequestTracker.getNewAddedValidRequests(requestPool, lastRequestPool); // write down new added requests
-            Set<PassengerRequest> removedRequests = RequestTracker.getRemovedRequests(requestPool, lastRequestPool); // write down removed request
-            Set<PassengerRequest> remainedRequests = RequestTracker.getRemainedRequests(requestPool, lastRequestPool); // write down remained request
+            Set<PassengerRequest> newAddedValidRequests = RequestTracker.getNewAddedValidRequests(requestPool,
+                    lastRequestPool); // write down new added requests
+            Set<PassengerRequest> removedRequests = RequestTracker.getRemovedRequests(requestPool, lastRequestPool); // write
+                                                                                                                     // down
+                                                                                                                     // removed
+                                                                                                                     // request
+            Set<PassengerRequest> remainedRequests = RequestTracker.getRemainedRequests(requestPool, lastRequestPool); // write
+                                                                                                                       // down
+                                                                                                                       // remained
+                                                                                                                       // request
 
             // remove the data from cache to release memory
-            removedRequests.stream().filter(avRequest -> !overduedRequests.contains(avRequest)).map(PassengerRequest::getFromLink).forEach(ttc::removeEntry);
+            removedRequests.stream().filter(avRequest -> !overduedRequests.contains(avRequest))
+                    .map(PassengerRequest::getFromLink).forEach(ttc::removeEntry);
 
             // RV diagram construction
-            Set<Set<PassengerRequest>> rvEdges = rvGenerator.generateRVGraph(newAddedValidRequests, removedRequests, remainedRequests, //
+            Set<Set<PassengerRequest>> rvEdges = rvGenerator.generateRVGraph(newAddedValidRequests, removedRequests,
+                    remainedRequests, //
                     now, ttc, requestKeyInfoMap);
 
-            // System.err.println("EDGE COUNT " + rvEdges.stream().mapToInt(x -> x.size()).sum());
+            // System.err.println("EDGE COUNT " + rvEdges.stream().mapToInt(x ->
+            // x.size()).sum());
 
             // RTV diagram construction (generate a list of edges between trip and vehicle)
-            List<TripWithVehicle> grossListOfRTVEdges = rtvGG.generateRTV(getInteractionlessRoboTaxis(), newAddedValidRequests, //
+            List<TripWithVehicle> grossListOfRTVEdges = rtvGG.generateRTV(getInteractionlessRoboTaxis(),
+                    newAddedValidRequests, //
                     removedRequests, now, requestKeyInfoMap, //
                     rvEdges, ttc, lastAssignment, trafficTimeAllowance);
 
@@ -192,10 +219,12 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
             List<TripWithVehicle> sharedTaxiAssignmentPlan = new ArrayList<>();
             if (!grossListOfRTVEdges.isEmpty()) {
                 // we need to find the number of taxi in ILP
-                List<RoboTaxi> listOfRoboTaxiWithValidTrip = grossListOfRTVEdges.stream().map(TripWithVehicle::getRoboTaxi).distinct().collect(Collectors.toList());
+                List<RoboTaxi> listOfRoboTaxiWithValidTrip = grossListOfRTVEdges.stream()
+                        .map(TripWithVehicle::getRoboTaxi).distinct().collect(Collectors.toList());
 
                 List<PassengerRequest> validOpenRequestList = new ArrayList<>(requestPool);
-                List<Double> iLPResultList = RunILP.of(grossListOfRTVEdges, validOpenRequestList, listOfRoboTaxiWithValidTrip, //
+                List<Double> iLPResultList = RunILP.of(grossListOfRTVEdges, validOpenRequestList,
+                        listOfRoboTaxiWithValidTrip, //
                         costOfIgnoredReuqestNormal, costOfIgnoredReuqestHigh, requestMatchedLastStep);
                 for (int i = 0; i < grossListOfRTVEdges.size(); i++)
                     if (iLPResultList.get(i) == 1)
@@ -228,7 +257,8 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
                 }
 
                 for (PassengerRequest avRequest : tripWithVehicle.getTrip())
-                    addSharedRoboTaxiPickup(roboTaxiToAssign, avRequest, pickupTimes.get(avRequest), dropoffTimes.get(avRequest));
+                    addSharedRoboTaxiPickup(roboTaxiToAssign, avRequest, pickupTimes.get(avRequest),
+                            dropoffTimes.get(avRequest));
                 // create set of requests in the route
                 Set<PassengerRequest> setOfPassengerRequestInRoute = routeToAssign.stream() //
                         .map(StopInRoute::getavRequest) //
@@ -249,14 +279,17 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
         }
 
         /** Re-balance */
-        if (rebalancePeriod > 0 && round_now % rebalancePeriod == 2) { // in order to avoid dispatch and re-balance happen at same time
+        if (rebalancePeriod > 0 && round_now % rebalancePeriod == 2) { // in order to avoid dispatch and re-balance
+                                                                       // happen at same time
             // check if there are both idling vehicles and unassigned requests at same time
             List<PassengerRequest> listOfUnassignedRequest = new ArrayList<>(getUnassignedRequests());
             List<RoboTaxi> listOfIdlingTaxi = new ArrayList<>(getDivertableUnassignedRoboTaxis());
 
             // for (RoboTaxi roboTaxi : getRoboTaxis()) {
-            // System.out.println("taxi id: " + roboTaxi.getId().toString() + ", link id:" + roboTaxi.getDivertableLocation().getId().toString() + //
-            // "status: " + roboTaxi.getStatus() + ", Number of passenger: " + RoboTaxiUtils.getNumberOnBoardRequests(roboTaxi));
+            // System.out.println("taxi id: " + roboTaxi.getId().toString() + ", link id:" +
+            // roboTaxi.getDivertableLocation().getId().toString() + //
+            // "status: " + roboTaxi.getStatus() + ", Number of passenger: " +
+            // RoboTaxiUtils.getNumberOnBoardRequests(roboTaxi));
             // }
 
             if (!listOfIdlingTaxi.isEmpty() && !listOfUnassignedRequest.isEmpty()) {
@@ -265,10 +298,13 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
                 List<RebalanceTripWithVehicle> listOfAllRebalanceTripWithVehicle = new ArrayList<>();
                 listOfAllRebalanceTripWithVehicle = RebalanceExplorer.of(listOfUnassignedRequest, listOfIdlingTaxi, //
                         now, ttc);
-                List<RebalanceTripWithVehicle> rebalancePlan = RebalancePlanGenerator.of(listOfAllRebalanceTripWithVehicle);
+                List<RebalanceTripWithVehicle> rebalancePlan = RebalancePlanGenerator
+                        .of(listOfAllRebalanceTripWithVehicle);
 
-                // assign Taxi to re-balance (first stop the taxi that is not in the new re-balance plan)
-                Set<RoboTaxi> roboTaxisInNewRebalancePlan = rebalancePlan.stream().map(RebalanceTripWithVehicle::getRoboTaxi).collect(Collectors.toSet());
+                // assign Taxi to re-balance (first stop the taxi that is not in the new
+                // re-balance plan)
+                Set<RoboTaxi> roboTaxisInNewRebalancePlan = rebalancePlan.stream()
+                        .map(RebalanceTripWithVehicle::getRoboTaxi).collect(Collectors.toSet());
                 for (RoboTaxi roboTaxi : listOfIdlingTaxi)
                     if (!roboTaxisInNewRebalancePlan.contains(roboTaxi))
                         setRoboTaxiRebalance(roboTaxi, roboTaxi.getDivertableLocation());
@@ -284,18 +320,19 @@ public class HighCapacityDispatcher extends RebalancingDispatcher {
     public static class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            Config config = inject.get(Config.class);
-            MatsimAmodeusDatabase db = inject.get(MatsimAmodeusDatabase.class);
-            EventsManager eventsManager = inject.get(EventsManager.class);
+            Config config = (Config) inject.get(Config.class);
+            MatsimAmodeusDatabase db = (MatsimAmodeusDatabase) inject.get(MatsimAmodeusDatabase.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
 
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
 
-            RebalancingStrategy rebalancingStrategy = inject.getModal(RebalancingStrategy.class);
+            RebalancingStrategy rebalancingStrategy = (RebalancingStrategy) inject.getModal(RebalancingStrategy.class);
 
-            return new HighCapacityDispatcher(network, config, operatorConfig, travelTime, router, eventsManager, db, rebalancingStrategy);
+            return new HighCapacityDispatcher(network, config, operatorConfig, travelTime, router, eventsManager, db,
+                    rebalancingStrategy);
         }
     }
 }

--- a/src/main/java/amodeus/amodeus/generator/RandomDensityGenerator.java
+++ b/src/main/java/amodeus/amodeus/generator/RandomDensityGenerator.java
@@ -15,14 +15,16 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.gbl.MatsimRandom;
 
-/** class generates {@link DvrpVehicle}s and places them at a random link.
+/**
+ * class generates {@link DvrpVehicle}s and places them at a random link.
  * each link is equally likely.
  *
  * all vehicles are created in this iteration. after that, no more AVVehiles are
- * added to the system. */
+ * added to the system.
+ */
 public class RandomDensityGenerator implements AmodeusGenerator {
     private static final Logger LOGGER = Logger.getLogger(RandomDensityGenerator.class);
     // ---
@@ -63,8 +65,8 @@ public class RandomDensityGenerator implements AmodeusGenerator {
     public static class Factory implements AmodeusGenerator.AVGeneratorFactory {
         @Override
         public AmodeusGenerator createGenerator(InstanceGetter inject) {
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
             int capacity = operatorConfig.getGeneratorConfig().getCapacity();
 
             return new RandomDensityGenerator(operatorConfig, network, capacity);

--- a/src/main/java/amodeus/amodeus/generator/VehicleToVSGenerator.java
+++ b/src/main/java/amodeus/amodeus/generator/VehicleToVSGenerator.java
@@ -14,7 +14,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 
 import com.google.inject.TypeLiteral;
 
@@ -32,14 +32,18 @@ import ch.ethz.idsc.tensor.red.Total;
 import ch.ethz.idsc.tensor.sca.Floor;
 import ch.ethz.idsc.tensor.sca.Sign;
 
-/** class generates {@link DvrpVehicle}s. It takes the required minimal initial vehicle numbers from
- * {@link TravelData}. In each virtual station it places the required number of vehicles.
+/**
+ * class generates {@link DvrpVehicle}s. It takes the required minimal initial
+ * vehicle numbers from
+ * {@link TravelData}. In each virtual station it places the required number of
+ * vehicles.
  * Within the virtual station a random link is chosen as initial destination.
  * If the minimal required vehicle numbers are reached,
  * the rest of the vehicles is distributed randomly among the virtual stations.
  * If no distribution is given, an equal distribution is chosen.
  * 
- * CLASS NAME IS USED AS IDENTIFIER - DO NOT RENAME CLASS */
+ * CLASS NAME IS USED AS IDENTIFIER - DO NOT RENAME CLASS
+ */
 public class VehicleToVSGenerator implements AmodeusGenerator {
     private static final long DEFAULT_RANDOM_SEED = 4711;
     // ---
@@ -60,7 +64,8 @@ public class VehicleToVSGenerator implements AmodeusGenerator {
 
         /** get distribution from travelData */
         Tensor v0 = travelData.getV0();
-        GlobalAssert.that(Total.of(v0).Get().number().intValue() <= operatorConfig.getGeneratorConfig().getNumberOfVehicles());
+        GlobalAssert.that(
+                Total.of(v0).Get().number().intValue() <= operatorConfig.getGeneratorConfig().getNumberOfVehicles());
 
         boolean noDistribution = Scalars.isZero(Total.of(v0).Get());
         long average = operatorConfig.getGeneratorConfig().getNumberOfVehicles() / virtualNetwork.getvNodesCount();
@@ -85,7 +90,8 @@ public class VehicleToVSGenerator implements AmodeusGenerator {
             Link linkGen = getNextLink(virtualNetwork.getVirtualNode(vNodeIndex));
             /** update placedVehicles */
             placedVehicles.set(RealScalar.ONE::add, vNodeIndex);
-            Id<DvrpVehicle> id = AmodeusIdentifiers.createVehicleId(operatorConfig.getMode(), generatedNumberOfVehicles);
+            Id<DvrpVehicle> id = AmodeusIdentifiers.createVehicleId(operatorConfig.getMode(),
+                    generatedNumberOfVehicles);
             vehicles.add(ImmutableDvrpVehicleSpecification.newBuilder() //
                     .id(id) //
                     .serviceBeginTime(0.0) //
@@ -97,7 +103,10 @@ public class VehicleToVSGenerator implements AmodeusGenerator {
         return vehicles;
     }
 
-    /** Returns the index of the first virtual station that is still in need of more vehicles. If all virtual stations have enough, return random index */
+    /**
+     * Returns the index of the first virtual station that is still in need of more
+     * vehicles. If all virtual stations have enough, return random index
+     */
     private int getNextVirtualNode() {
         for (int i = 0; i < virtualNetwork.getvNodesCount(); i++)
             if (Sign.isPositive(vehicleDistribution.Get(i).subtract(placedVehicles.Get(i))))
@@ -105,7 +114,10 @@ public class VehicleToVSGenerator implements AmodeusGenerator {
         return random.nextInt(virtualNetwork.getvNodesCount());
     }
 
-    /** Return a random {@link Link} of the according virtual station with index vNodeIndex */
+    /**
+     * Return a random {@link Link} of the according virtual station with index
+     * vNodeIndex
+     */
     protected Link getNextLink(VirtualNode<Link> vNode) {
         Collection<Link> links = vNode.getLinks();
         List<Link> sortedLinks = SortedLinks.of(links); /** needed for identical outcome with a certain random seed */
@@ -121,12 +133,13 @@ public class VehicleToVSGenerator implements AmodeusGenerator {
     public static class Factory implements AmodeusGenerator.AVGeneratorFactory {
         @Override
         public AmodeusGenerator createGenerator(InstanceGetter inject) {
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
             int capacity = operatorConfig.getGeneratorConfig().getCapacity();
 
-            VirtualNetwork<Link> virtualNetwork = inject.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-            });
-            TravelData travelData = inject.getModal(TravelData.class);
+            VirtualNetwork<Link> virtualNetwork = (VirtualNetwork<Link>) inject
+                    .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                    });
+            TravelData travelData = (TravelData) inject.getModal(TravelData.class);
 
             return new VehicleToVSGenerator(operatorConfig, virtualNetwork, travelData, capacity);
         }

--- a/src/main/java/amodeus/amodeus/linkspeed/TaxiTravelTimeRouter.java
+++ b/src/main/java/amodeus/amodeus/linkspeed/TaxiTravelTimeRouter.java
@@ -11,7 +11,7 @@ import org.matsim.amodeus.plpc.ParallelLeastCostPathCalculator;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.router.DijkstraFactory;
 import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutility;
@@ -22,9 +22,11 @@ import org.matsim.vehicles.Vehicle;
 import amodeus.amodeus.dispatcher.core.RoboTaxi;
 import amodeus.amodeus.util.io.MultiFileTools;
 
-/** This is a nonfunctional sample demonstrating of how to include a custom
+/**
+ * This is a nonfunctional sample demonstrating of how to include a custom
  * router to AMoDeus which is not the standard choice of the Paralllel Djikstra
- * router used normally to calculate the path for {@link RoboTaxi} */
+ * router used normally to calculate the path for {@link RoboTaxi}
+ */
 public class TaxiTravelTimeRouter implements AmodeusRouter {
     private final ParallelLeastCostPathCalculator delegate;
 
@@ -33,7 +35,8 @@ public class TaxiTravelTimeRouter implements AmodeusRouter {
     }
 
     @Override
-    public Future<Path> calcLeastCostPath(Node fromNode, Node toNode, double starttime, Person person, Vehicle vehicle) {
+    public Future<Path> calcLeastCostPath(Node fromNode, Node toNode, double starttime, Person person,
+            Vehicle vehicle) {
         return delegate.calcLeastCostPath(fromNode, toNode, starttime, person, vehicle);
     }
 
@@ -50,8 +53,8 @@ public class TaxiTravelTimeRouter implements AmodeusRouter {
 
         @Override
         public AmodeusRouter createRouter(InstanceGetter inject) {
-            GlobalConfigGroup config = inject.get(GlobalConfigGroup.class);
-            Network network = inject.getModal(Network.class);
+            GlobalConfigGroup config = (GlobalConfigGroup) inject.get(GlobalConfigGroup.class);
+            Network network = (Network) inject.getModal(Network.class);
 
             TravelTime travelTime = new LSDataTravelTime(lsData);
 

--- a/src/main/java/amodeus/amodeus/routing/DefaultAStarLMRouter.java
+++ b/src/main/java/amodeus/amodeus/routing/DefaultAStarLMRouter.java
@@ -10,15 +10,17 @@ import org.matsim.amodeus.plpc.ParallelLeastCostPathCalculator;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.Vehicle;
 
-/** The DefaultAStarLMRouter is a standard ParallelLeastCostPathCalculator using
- * A* Landmarks routing algorithm. */
+/**
+ * The DefaultAStarLMRouter is a standard ParallelLeastCostPathCalculator using
+ * A* Landmarks routing algorithm.
+ */
 public class DefaultAStarLMRouter implements AmodeusRouter {
     final private ParallelLeastCostPathCalculator delegate;
 
@@ -40,9 +42,9 @@ public class DefaultAStarLMRouter implements AmodeusRouter {
     public static class Factory implements AmodeusRouter.Factory {
         @Override
         public AmodeusRouter createRouter(InstanceGetter inject) {
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            GlobalConfigGroup config = inject.get(GlobalConfigGroup.class);
-            Network network = inject.getModal(Network.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            GlobalConfigGroup config = (GlobalConfigGroup) inject.get(GlobalConfigGroup.class);
+            Network network = (Network) inject.getModal(Network.class);
 
             return new DefaultAStarLMRouter(DefaultParallelLeastCostPathCalculator.//
                     create(config.getNumberOfThreads(), new FastAStarLandmarksFactory(config), network, //

--- a/src/main/java/org/matsim/amodeus/components/AmodeusDispatcher.java
+++ b/src/main/java/org/matsim/amodeus/components/AmodeusDispatcher.java
@@ -2,7 +2,7 @@ package org.matsim.amodeus.components;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.modal.ModalProviders;
 
 public interface AmodeusDispatcher {
     void onRequestSubmitted(PassengerRequest request);

--- a/src/main/java/org/matsim/amodeus/components/AmodeusGenerator.java
+++ b/src/main/java/org/matsim/amodeus/components/AmodeusGenerator.java
@@ -3,7 +3,7 @@ package org.matsim.amodeus.components;
 import java.util.List;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
-import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.modal.ModalProviders;
 
 public interface AmodeusGenerator {
     List<DvrpVehicleSpecification> generateVehicles();

--- a/src/main/java/org/matsim/amodeus/components/AmodeusRouter.java
+++ b/src/main/java/org/matsim/amodeus/components/AmodeusRouter.java
@@ -1,7 +1,7 @@
 package org.matsim.amodeus.components;
 
 import org.matsim.amodeus.plpc.ParallelLeastCostPathCalculator;
-import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.modal.ModalProviders;
 
 public interface AmodeusRouter extends ParallelLeastCostPathCalculator {
     interface Factory {

--- a/src/main/java/org/matsim/amodeus/components/dispatcher/single_fifo/SingleFIFODispatcher.java
+++ b/src/main/java/org/matsim/amodeus/components/dispatcher/single_fifo/SingleFIFODispatcher.java
@@ -11,7 +11,7 @@ import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.router.util.TravelTime;
@@ -75,12 +75,13 @@ public class SingleFIFODispatcher implements AmodeusDispatcher {
     static public class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            EventsManager eventsManager = inject.get(EventsManager.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
 
-            return new SingleFIFODispatcher(operatorConfig.getMode(), eventsManager, new SingleRideAppender(operatorConfig.getTimingConfig(), router, travelTime));
+            return new SingleFIFODispatcher(operatorConfig.getMode(), eventsManager,
+                    new SingleRideAppender(operatorConfig.getTimingConfig(), router, travelTime));
         }
     }
 }

--- a/src/main/java/org/matsim/amodeus/components/dispatcher/single_heuristic/SingleHeuristicDispatcher.java
+++ b/src/main/java/org/matsim/amodeus/components/dispatcher/single_heuristic/SingleHeuristicDispatcher.java
@@ -16,7 +16,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.network.NetworkUtils;
@@ -49,7 +49,8 @@ public class SingleHeuristicDispatcher implements AmodeusDispatcher {
 
     private HeuristicMode dispatcherMode = HeuristicMode.OVERSUPPLY;
 
-    public SingleHeuristicDispatcher(String mode, EventsManager eventsManager, Network network, SingleRideAppender appender, double replanningInterval) {
+    public SingleHeuristicDispatcher(String mode, EventsManager eventsManager, Network network,
+            SingleRideAppender appender, double replanningInterval) {
         this.appender = appender;
         this.mode = mode;
         this.eventsManager = eventsManager;
@@ -75,7 +76,8 @@ public class SingleHeuristicDispatcher implements AmodeusDispatcher {
     }
 
     private void reoptimize(double now) {
-        HeuristicMode updatedMode = availableVehicles.size() > pendingRequests.size() ? HeuristicMode.OVERSUPPLY : HeuristicMode.UNDERSUPPLY;
+        HeuristicMode updatedMode = availableVehicles.size() > pendingRequests.size() ? HeuristicMode.OVERSUPPLY
+                : HeuristicMode.UNDERSUPPLY;
 
         if (!updatedMode.equals(dispatcherMode)) {
             dispatcherMode = updatedMode;
@@ -87,14 +89,14 @@ public class SingleHeuristicDispatcher implements AmodeusDispatcher {
             DvrpVehicle vehicle = null;
 
             switch (dispatcherMode) {
-            case OVERSUPPLY:
-                request = findRequest();
-                vehicle = findClosestVehicle(request.getFromLink());
-                break;
-            case UNDERSUPPLY:
-                vehicle = findVehicle();
-                request = findClosestRequest(vehicleLinks.get(vehicle));
-                break;
+                case OVERSUPPLY:
+                    request = findRequest();
+                    vehicle = findClosestVehicle(request.getFromLink());
+                    break;
+                case UNDERSUPPLY:
+                    vehicle = findVehicle();
+                    request = findClosestRequest(vehicleLinks.get(vehicle));
+                    break;
             }
 
             removeRequest(request);
@@ -180,15 +182,17 @@ public class SingleHeuristicDispatcher implements AmodeusDispatcher {
     static public class Factory implements AVDispatcherFactory {
         @Override
         public AmodeusDispatcher createDispatcher(InstanceGetter inject) {
-            EventsManager eventsManager = inject.get(EventsManager.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            AmodeusModeConfig operatorConfig = inject.getModal(AmodeusModeConfig.class);
-            AmodeusRouter router = inject.getModal(AmodeusRouter.class);
-            Network network = inject.getModal(Network.class);
+            EventsManager eventsManager = (EventsManager) inject.get(EventsManager.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            AmodeusModeConfig operatorConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            AmodeusRouter router = (AmodeusRouter) inject.getModal(AmodeusRouter.class);
+            Network network = (Network) inject.getModal(Network.class);
 
-            double replanningInterval = Double.parseDouble(operatorConfig.getDispatcherConfig().getParams().getOrDefault("replanningInterval", "10.0"));
+            double replanningInterval = Double.parseDouble(
+                    operatorConfig.getDispatcherConfig().getParams().getOrDefault("replanningInterval", "10.0"));
 
-            return new SingleHeuristicDispatcher(operatorConfig.getMode(), eventsManager, network, new SingleRideAppender(operatorConfig.getTimingConfig(), router, travelTime),
+            return new SingleHeuristicDispatcher(operatorConfig.getMode(), eventsManager, network,
+                    new SingleRideAppender(operatorConfig.getTimingConfig(), router, travelTime),
                     replanningInterval);
         }
     }

--- a/src/main/java/org/matsim/amodeus/components/generator/PopulationDensityGenerator.java
+++ b/src/main/java/org/matsim/amodeus/components/generator/PopulationDensityGenerator.java
@@ -18,7 +18,7 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.facilities.ActivityFacilities;
 
 public class PopulationDensityGenerator implements AmodeusGenerator {
@@ -32,7 +32,8 @@ public class PopulationDensityGenerator implements AmodeusGenerator {
     private List<Link> linkList = new LinkedList<>();
     private Map<Link, Double> cumulativeDensity = new HashMap<>();
 
-    public PopulationDensityGenerator(String mode, int numberOfVehicles, Network network, Population population, ActivityFacilities facilities, int randomSeed, int capacity) {
+    public PopulationDensityGenerator(String mode, int numberOfVehicles, Network network, Population population,
+            ActivityFacilities facilities, int randomSeed, int capacity) {
         this.randomSeed = randomSeed;
         this.numberOfVehicles = numberOfVehicles;
         this.capacity = capacity;
@@ -44,7 +45,8 @@ public class PopulationDensityGenerator implements AmodeusGenerator {
 
         for (Person person : population.getPersons().values()) {
             Activity act = (Activity) person.getSelectedPlan().getPlanElements().get(0);
-            Id<Link> linkId = act.getLinkId() != null ? act.getLinkId() : facilities.getFacilities().get(act.getFacilityId()).getLinkId();
+            Id<Link> linkId = act.getLinkId() != null ? act.getLinkId()
+                    : facilities.getFacilities().get(act.getFacilityId()).getLinkId();
             Link link = network.getLinks().get(linkId);
 
             if (link != null) {
@@ -108,17 +110,18 @@ public class PopulationDensityGenerator implements AmodeusGenerator {
     static public class Factory implements AmodeusGenerator.AVGeneratorFactory {
         @Override
         public AmodeusGenerator createGenerator(InstanceGetter inject) {
-            AmodeusModeConfig modeConfig = inject.getModal(AmodeusModeConfig.class);
-            Network network = inject.getModal(Network.class);
+            AmodeusModeConfig modeConfig = (AmodeusModeConfig) inject.getModal(AmodeusModeConfig.class);
+            Network network = (Network) inject.getModal(Network.class);
 
-            Population population = inject.get(Population.class);
-            ActivityFacilities facilities = inject.get(ActivityFacilities.class);
+            Population population = (Population) inject.get(Population.class);
+            ActivityFacilities facilities = (ActivityFacilities) inject.get(ActivityFacilities.class);
 
             GeneratorConfig generatorConfig = modeConfig.getGeneratorConfig();
             int capacity = generatorConfig.getCapacity();
             int randomSeed = Integer.parseInt(generatorConfig.getParams().getOrDefault("randomSeed", "1234"));
 
-            return new PopulationDensityGenerator(modeConfig.getMode(), generatorConfig.getNumberOfVehicles(), network, population, facilities, randomSeed, capacity);
+            return new PopulationDensityGenerator(modeConfig.getMode(), generatorConfig.getNumberOfVehicles(), network,
+                    population, facilities, randomSeed, capacity);
         }
     }
 }

--- a/src/main/java/org/matsim/amodeus/components/router/DefaultAmodeusRouter.java
+++ b/src/main/java/org/matsim/amodeus/components/router/DefaultAmodeusRouter.java
@@ -10,15 +10,17 @@ import org.matsim.amodeus.plpc.ParallelLeastCostPathCalculator;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.router.DijkstraFactory;
 import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutility;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.Vehicle;
 
-/** The DefaultAVRouter is a standard ParallelLeastCostPathCalculator using
- * Djikstra's algorithm. */
+/**
+ * The DefaultAVRouter is a standard ParallelLeastCostPathCalculator using
+ * Djikstra's algorithm.
+ */
 public class DefaultAmodeusRouter implements AmodeusRouter {
     public final static String TYPE = "Default";
 
@@ -29,7 +31,8 @@ public class DefaultAmodeusRouter implements AmodeusRouter {
     }
 
     @Override
-    public Future<Path> calcLeastCostPath(Node fromNode, Node toNode, double starttime, Person person, Vehicle vehicle) {
+    public Future<Path> calcLeastCostPath(Node fromNode, Node toNode, double starttime, Person person,
+            Vehicle vehicle) {
         return delegate.calcLeastCostPath(fromNode, toNode, starttime, person, vehicle);
     }
 
@@ -41,11 +44,12 @@ public class DefaultAmodeusRouter implements AmodeusRouter {
     public static class Factory implements AmodeusRouter.Factory {
         @Override
         public AmodeusRouter createRouter(InstanceGetter inject) {
-            Network network = inject.getModal(Network.class);
-            TravelTime travelTime = inject.getModal(TravelTime.class);
-            AmodeusConfigGroup config = inject.get(AmodeusConfigGroup.class);
+            Network network = (Network) inject.getModal(Network.class);
+            TravelTime travelTime = (TravelTime) inject.getModal(TravelTime.class);
+            AmodeusConfigGroup config = (AmodeusConfigGroup) inject.get(AmodeusConfigGroup.class);
 
-            return new DefaultAmodeusRouter(DefaultParallelLeastCostPathCalculator.create((int) config.getNumberOfParallelRouters(), new DijkstraFactory(), network,
+            return new DefaultAmodeusRouter(DefaultParallelLeastCostPathCalculator.create(
+                    (int) config.getNumberOfParallelRouters(), new DijkstraFactory(), network,
                     new OnlyTimeDependentTravelDisutility(travelTime), travelTime));
         }
     }

--- a/src/main/java/org/matsim/amodeus/dvrp/schedule/AmodeusStopTask.java
+++ b/src/main/java/org/matsim/amodeus/dvrp/schedule/AmodeusStopTask.java
@@ -7,16 +7,16 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
-public class AmodeusStopTask extends StayTask {
+public class AmodeusStopTask extends DefaultStayTask {
     public enum StopType {
         Pickup, Dropoff
     }
-    
+
     private final Map<Id<Request>, PassengerRequest> pickupRequests = new HashMap<>();
     private final Map<Id<Request>, PassengerRequest> dropoffRequests = new HashMap<>();
-    
+
     private final StopType stopType;
 
     public AmodeusStopTask(double beginTime, double endTime, Link link, StopType stopType) {
@@ -39,7 +39,7 @@ public class AmodeusStopTask extends StayTask {
     public Map<Id<Request>, PassengerRequest> getDropoffRequests() {
         return dropoffRequests;
     }
-    
+
     public StopType getStopType() {
         return stopType;
     }

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
@@ -22,6 +22,7 @@ import org.matsim.contrib.dvrp.passenger.DefaultPassengerRequestValidator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.modal.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
@@ -92,7 +93,7 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         bindModal(RebalancingStrategy.class).toInstance(new NoRebalancingStrategy());
     }
 
-    static private class RoutingModuleProvider extends ModalProviders.AbstractProvider<AmodeusRoutingModule> {
+    static private class RoutingModuleProvider extends ModalProviders.AbstractProvider<DvrpMode, AmodeusRoutingModule> {
         @Inject
         AmodeusRouteFactory routeFactory;
 
@@ -111,7 +112,7 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         LeastCostPathCalculatorFactory routerFactory;
 
         RoutingModuleProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override
@@ -135,12 +136,13 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         }
     };
 
-    static private class InteractionFinderProvider extends ModalProviders.AbstractProvider<AmodeusInteractionFinder> {
+    static private class InteractionFinderProvider
+            extends ModalProviders.AbstractProvider<DvrpMode, AmodeusInteractionFinder> {
         @Inject
         Map<String, AmodeusInteractionFinder.AVInteractionFinderFactory> factories;
 
         InteractionFinderProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override
@@ -160,9 +162,9 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         }
     };
 
-    static class PriceCalculatorProider extends ModalProviders.AbstractProvider<PriceModel> {
+    static class PriceCalculatorProider extends ModalProviders.AbstractProvider<DvrpMode, PriceModel> {
         PriceCalculatorProider(AmodeusModeConfig modeConfig) {
-            super(modeConfig.getMode());
+            super(modeConfig.getMode(), DvrpModes::mode);
         }
 
         @Override

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
@@ -35,7 +35,6 @@ import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Inject;
 import com.google.inject.Key;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
@@ -60,9 +59,9 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
 
         // Routing module
         bindModal(AmodeusRoutingModule.class)
-                .toProvider((Provider<? extends AmodeusRoutingModule>) new RoutingModuleProvider(getMode()));
+                .toProvider(new RoutingModuleProvider(getMode()));
         bindModal(AmodeusInteractionFinder.class)
-                .toProvider((Provider<? extends AmodeusInteractionFinder>) new InteractionFinderProvider(getMode()))
+                .toProvider(new InteractionFinderProvider(getMode()))
                 .in(Singleton.class);
         addRoutingModuleBinding(getMode()).to(modalKey(AmodeusRoutingModule.class));
 
@@ -86,7 +85,7 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         // Waiting time estimation
         install(new WaitingTimeEstimationModule(modeConfig));
 
-        bindModal(PriceModel.class).toProvider((Provider<? extends PriceModel>) new PriceCalculatorProider(modeConfig));
+        bindModal(PriceModel.class).toProvider(new PriceCalculatorProider(modeConfig));
 
         install(new VirtualNetworkModeModule(modeConfig));
 

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeModule.java
@@ -117,7 +117,6 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
         @Override
         public AmodeusRoutingModule get() {
             AmodeusModeConfig modeConfig = getModalInstance(AmodeusModeConfig.class);
-            boolean predictRoute = modeConfig.getPredictRouteTravelTime() || modeConfig.getPredictRoutePrice();
             boolean useAccessEgress = modeConfig.getUseAccessEgress();
 
             AmodeusInteractionFinder interactionFinder = getModalInstance(AmodeusInteractionFinder.class);
@@ -130,7 +129,7 @@ public class AmodeusModeModule extends AbstractDvrpModeModule {
             LeastCostPathCalculator router = routerFactory.createPathCalculator(network, travelDisutility, travelTime);
 
             return new AmodeusRoutingModule(routeFactory, interactionFinder, waitingTime, populationFactory,
-                    walkRoutingModule, useAccessEgress, predictRoute, router,
+                    walkRoutingModule, useAccessEgress, router,
                     priceCalculator, network, travelTime, getMode());
         }
     };

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
@@ -25,6 +25,7 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.core.modal.ModalAnnotationCreator;
 import org.matsim.core.modal.ModalProviders;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic.DynActionCreator;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
@@ -40,6 +41,8 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
     public AmodeusModeQSimModule(AmodeusModeConfig modeConfig) {
         super(modeConfig.getMode());
     }
+
+    private final ModalAnnotationCreator<DvrpMode> modalAnnotationCreator = DvrpModes::mode;
 
     @Override
     protected void configureQSim() {
@@ -89,7 +92,8 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
             return new AmodeusOptimizer(dispatcher, eventsManager);
         })).in(Singleton.class);
         addModalQSimComponentBinding().to(modalKey(AmodeusOptimizer.class));
-        bindModal(VrpOptimizer.class).to(DvrpModes.key(AmodeusOptimizer.class, getMode())).in(Singleton.class);
+        bindModal(VrpOptimizer.class).to(modalAnnotationCreator.key(AmodeusOptimizer.class, getMode()))
+                .in(Singleton.class);
 
         bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {
             AmodeusOptimizer optimizer = getter.getModal(AmodeusOptimizer.class);

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
@@ -25,13 +25,15 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalAnnotationCreator;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic.DynActionCreator;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.core.modal.ModalAnnotationCreator;
+import org.matsim.core.modal.ModalProviders;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Singleton;
@@ -50,6 +52,11 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
         bindModal(PassengerRequestCreator.class).toProvider(modalProvider(getter -> {
             return new AmodeusRequestCreator(getMode());
         })).in(Singleton.class);
+
+        // this is needed due to these changes. This does mean the vehicle type will
+        // always be default
+        // https://github.com/matsim-org/matsim-libs/pull/1822/files
+        bindModal(VehicleType.class).toInstance(VehicleUtils.getDefaultVehicleType());
 
         bindModal(DynActionCreator.class).toProvider(modalProvider(getter -> {
             PassengerEngine passengerEngine = getter.getModal(PassengerEngine.class);

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
@@ -34,7 +34,6 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.qsim.QSim;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
 public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
@@ -83,7 +82,7 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
             return getter.get(GeneratorRegistry.class).get(generatorName).createGenerator(getter);
         })).in(Singleton.class);
 
-        bindModal(Fleet.class).toProvider((Provider<? extends Fleet>) new FleetProvider(getMode())).in(Singleton.class);
+        bindModal(Fleet.class).toProvider(new FleetProvider(getMode())).in(Singleton.class);
 
         bindModal(AmodeusOptimizer.class).toProvider(modalProvider(getter -> {
             EventsManager eventsManager = getter.get(EventsManager.class);

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
@@ -23,6 +23,7 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.modal.ModalProviders;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic.DynActionCreator;
@@ -100,9 +101,9 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
         })).in(Singleton.class);
     }
 
-    static private class FleetProvider extends ModalProviders.AbstractProvider<Fleet> {
+    static private class FleetProvider extends ModalProviders.AbstractProvider<DvrpMode, Fleet> {
         FleetProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override

--- a/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/AmodeusModeQSimModule.java
@@ -91,7 +91,8 @@ public class AmodeusModeQSimModule extends AbstractDvrpModeQSimModule {
             return new AmodeusOptimizer(dispatcher, eventsManager);
         })).in(Singleton.class);
         addModalQSimComponentBinding().to(modalKey(AmodeusOptimizer.class));
-        bindModal(VrpOptimizer.class).to(modalAnnotationCreator.key(AmodeusOptimizer.class, getMode()))
+        bindModal(VrpOptimizer.class).to(modalAnnotationCreator.key(AmodeusOptimizer.class,
+                getMode()))
                 .in(Singleton.class);
 
         bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {

--- a/src/main/java/org/matsim/amodeus/framework/VirtualNetworkModeModule.java
+++ b/src/main/java/org/matsim/amodeus/framework/VirtualNetworkModeModule.java
@@ -13,7 +13,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 
@@ -31,7 +31,10 @@ import amodeus.amodeus.virtualnetwork.core.VirtualNetwork;
 import amodeus.amodeus.virtualnetwork.core.VirtualNetworkGet;
 import amodeus.amodeus.virtualnetwork.core.VirtualNetworkIO;
 
-/** provides the {@link VirtualNetwork} and {@link TravelData} and therefore {@link VirtualNetworkPreparer} has to be run in the Preparer */
+/**
+ * provides the {@link VirtualNetwork} and {@link TravelData} and therefore
+ * {@link VirtualNetworkPreparer} has to be run in the Preparer
+ */
 public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
     private final static Logger logger = Logger.getLogger(VirtualNetworkModeModule.class);
 
@@ -50,14 +53,16 @@ public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
 
     static private VirtualNetwork<Link> provideVirtualNetworkFromScenarioOptions(InstanceGetter getter) {
         try {
-            AmodeusModeConfig modeConfig = getter.getModal(AmodeusModeConfig.class);
-            ScenarioOptions scenarioOptions = getter.get(ScenarioOptions.class);
+            AmodeusModeConfig modeConfig = (AmodeusModeConfig) getter.getModal(AmodeusModeConfig.class);
+            ScenarioOptions scenarioOptions = (ScenarioOptions) getter.get(ScenarioOptions.class);
 
-            logger.info(String.format("Loading VirtualNetwork for mode '%s' from ScenarioOptions:", modeConfig.getMode()));
-            logger.info(String.format("  - creator: ", scenarioOptions.getVirtualNetworkCreator().getClass().getSimpleName()));
+            logger.info(
+                    String.format("Loading VirtualNetwork for mode '%s' from ScenarioOptions:", modeConfig.getMode()));
+            logger.info(String.format("  - creator: ",
+                    scenarioOptions.getVirtualNetworkCreator().getClass().getSimpleName()));
             logger.info(String.format("  - name: ", scenarioOptions.getVirtualNetworkName()));
 
-            Network network = getter.getModal(Network.class);
+            Network network = (Network) getter.getModal(Network.class);
             return VirtualNetworkGet.readDefault(network, scenarioOptions);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -66,30 +71,36 @@ public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
 
     static private VirtualNetwork<Link> provideVirtualNetworkFromConfig(InstanceGetter getter) {
         try {
-            ScenarioOptions scenarioOptions = getter.get(ScenarioOptions.class);
-            Config config = getter.get(Config.class);
-            Population population = getter.get(Population.class);
+            ScenarioOptions scenarioOptions = (ScenarioOptions) getter.get(ScenarioOptions.class);
+            Config config = (Config) getter.get(Config.class);
+            Population population = (Population) getter.get(Population.class);
 
-            AmodeusModeConfig modeConfig = getter.getModal(AmodeusModeConfig.class);
+            AmodeusModeConfig modeConfig = (AmodeusModeConfig) getter.getModal(AmodeusModeConfig.class);
             DispatcherConfig dispatcherConfig = modeConfig.getDispatcherConfig();
-            Network network = getter.getModal(Network.class);
+            Network network = (Network) getter.getModal(Network.class);
 
-            URL virtualNetworkUrl = ConfigGroup.getInputFileURL(config.getContext(), dispatcherConfig.getVirtualNetworkPath());
+            URL virtualNetworkUrl = ConfigGroup.getInputFileURL(config.getContext(),
+                    dispatcherConfig.getVirtualNetworkPath());
             File virtualNetworkFile = new File(virtualNetworkUrl.getPath());
 
             if (!virtualNetworkFile.exists() || dispatcherConfig.getRegenerateVirtualNetwork()) {
-                logger.info(String.format("Regenerating VirtualNetwork for mode '%s' at '%s'", modeConfig.getMode(), virtualNetworkFile));
-                logger.info("Currently we use information from ScenarioOptions for that. Later on this should be moved to a specific config module.");
-                logger.info(String.format("Using VirtualNetworkCreator: %s", scenarioOptions.getVirtualNetworkCreator().getClass().getSimpleName()));
+                logger.info(String.format("Regenerating VirtualNetwork for mode '%s' at '%s'", modeConfig.getMode(),
+                        virtualNetworkFile));
+                logger.info(
+                        "Currently we use information from ScenarioOptions for that. Later on this should be moved to a specific config module.");
+                logger.info(String.format("Using VirtualNetworkCreator: %s",
+                        scenarioOptions.getVirtualNetworkCreator().getClass().getSimpleName()));
 
                 int numberOfVehicles = modeConfig.getGeneratorConfig().getNumberOfVehicles();
-                VirtualNetwork<Link> virtualNetwork = scenarioOptions.getVirtualNetworkCreator().create(network, population, scenarioOptions, numberOfVehicles, //
+                VirtualNetwork<Link> virtualNetwork = scenarioOptions.getVirtualNetworkCreator().create(network,
+                        population, scenarioOptions, numberOfVehicles, //
                         (int) config.qsim().getEndTime().seconds());
 
                 VirtualNetworkIO.toByte(virtualNetworkFile, virtualNetwork);
             }
 
-            logger.info(String.format("Loading VirtualNetwork for operator '%s' from '%s'", modeConfig.getMode(), virtualNetworkFile));
+            logger.info(String.format("Loading VirtualNetwork for operator '%s' from '%s'", modeConfig.getMode(),
+                    virtualNetworkFile));
             return VirtualNetworkGet.readFile(network, virtualNetworkFile);
         } catch (IOException | ClassNotFoundException | DataFormatException e) {
             throw new RuntimeException(e);
@@ -103,7 +114,8 @@ public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
             // If nothing is set in the configuration file, we fall back to ScenarioOptions.
 
             bindModal(new TypeLiteral<VirtualNetwork<Link>>() {
-            }).toProvider(modalProvider(VirtualNetworkModeModule::provideVirtualNetworkFromScenarioOptions)).in(Singleton.class);
+            }).toProvider(modalProvider(VirtualNetworkModeModule::provideVirtualNetworkFromScenarioOptions))
+                    .in(Singleton.class);
         } else {
             bindModal(new TypeLiteral<VirtualNetwork<Link>>() {
             }).toProvider(modalProvider(VirtualNetworkModeModule::provideVirtualNetworkFromConfig)).in(Singleton.class);
@@ -111,48 +123,54 @@ public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
     }
 
     static private TravelData provideTravelDataFromScenarioOptions(InstanceGetter getter) {
-        AmodeusModeConfig modeConfig = getter.getModal(AmodeusModeConfig.class);
-        ScenarioOptions scenarioOptions = getter.get(ScenarioOptions.class);
+        AmodeusModeConfig modeConfig = (AmodeusModeConfig) getter.getModal(AmodeusModeConfig.class);
+        ScenarioOptions scenarioOptions = (ScenarioOptions) getter.get(ScenarioOptions.class);
 
         logger.info(String.format("Loading TravelData for mode '%s' from ScenarioOptions:", modeConfig.getMode()));
         logger.info(String.format("  - name: ", scenarioOptions.getTravelDataName()));
 
-        VirtualNetwork<Link> virtualNetwork = getter.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-        });
+        VirtualNetwork<Link> virtualNetwork = (VirtualNetwork<Link>) getter
+                .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                });
 
         return TravelDataGet.readStatic(virtualNetwork, scenarioOptions);
     }
 
     static private TravelData provideTravelDataFromConfig(InstanceGetter getter) {
         try {
-            AmodeusModeConfig modeConfig = getter.getModal(AmodeusModeConfig.class);
+            AmodeusModeConfig modeConfig = (AmodeusModeConfig) getter.getModal(AmodeusModeConfig.class);
             DispatcherConfig dispatcherConfig = modeConfig.getDispatcherConfig();
 
-            VirtualNetwork<Link> virtualNetwork = getter.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-            });
-            Network network = getter.getModal(Network.class);
-            Config config = getter.get(Config.class);
-            ScenarioOptions scenarioOptions = getter.get(ScenarioOptions.class);
-            Population population = getter.get(Population.class);
+            VirtualNetwork<Link> virtualNetwork = (VirtualNetwork<Link>) getter
+                    .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                    });
+            Network network = (Network) getter.getModal(Network.class);
+            Config config = (Config) getter.get(Config.class);
+            ScenarioOptions scenarioOptions = (ScenarioOptions) getter.get(ScenarioOptions.class);
+            Population population = (Population) getter.get(Population.class);
 
             URL travelDataUrl = ConfigGroup.getInputFileURL(config.getContext(), dispatcherConfig.getTravelDataPath());
             File travelDataFile = new File(travelDataUrl.getPath());
 
             if (!travelDataFile.exists() || dispatcherConfig.getRegenerateTravelData()) {
-                logger.info(String.format("Regenerating TravelData for mode '%s' at '%s'", modeConfig.getMode(), travelDataFile));
-                logger.info("Currently we use information from ScenarioOptions for that. Later on this should be moved to a specific config module.");
+                logger.info(String.format("Regenerating TravelData for mode '%s' at '%s'", modeConfig.getMode(),
+                        travelDataFile));
+                logger.info(
+                        "Currently we use information from ScenarioOptions for that. Later on this should be moved to a specific config module.");
                 logger.info("Using StaticTravelDataCreator");
 
                 File workingDirectory = new File(config.getContext().getPath()).getParentFile();
                 int numberOfVehicles = modeConfig.getGeneratorConfig().getNumberOfVehicles();
                 int interval = scenarioOptions.getdtTravelData();
 
-                StaticTravelData travelData = StaticTravelDataCreator.create(workingDirectory, virtualNetwork, network, population, interval, numberOfVehicles, //
+                StaticTravelData travelData = StaticTravelDataCreator.create(workingDirectory, virtualNetwork, network,
+                        population, interval, numberOfVehicles, //
                         (int) config.qsim().getEndTime().seconds());
                 TravelDataIO.writeStatic(travelDataFile, travelData);
             }
 
-            logger.info(String.format("Loading TravelData for mode '%s' from '%s'", modeConfig.getMode(), travelDataFile));
+            logger.info(
+                    String.format("Loading TravelData for mode '%s' from '%s'", modeConfig.getMode(), travelDataFile));
             return TravelDataGet.readFile(virtualNetwork, travelDataFile);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -165,9 +183,12 @@ public class VirtualNetworkModeModule extends AbstractDvrpModeModule {
         if (travelDataPath == null) {
             // If nothing is set in the configuration file, we fall back to ScenarioOptions.
 
-            bindModal(TravelData.class).toProvider(modalProvider(VirtualNetworkModeModule::provideTravelDataFromScenarioOptions)).in(Singleton.class);
+            bindModal(TravelData.class)
+                    .toProvider(modalProvider(VirtualNetworkModeModule::provideTravelDataFromScenarioOptions))
+                    .in(Singleton.class);
         } else {
-            bindModal(TravelData.class).toProvider(modalProvider(VirtualNetworkModeModule::provideTravelDataFromConfig)).in(Singleton.class);
+            bindModal(TravelData.class).toProvider(modalProvider(VirtualNetworkModeModule::provideTravelDataFromConfig))
+                    .in(Singleton.class);
         }
     }
 }

--- a/src/main/java/org/matsim/amodeus/routing/AmodeusRoutingModule.java
+++ b/src/main/java/org/matsim/amodeus/routing/AmodeusRoutingModule.java
@@ -38,13 +38,12 @@ public class AmodeusRoutingModule implements RoutingModule {
     private final AmodeusInteractionFinder interactionFinder;
     private final WaitingTime waitingTime;
     private final boolean useAccessEgress;
-    private final boolean predictRoute;
 
     private final String mode;
 
     public AmodeusRoutingModule(AmodeusRouteFactory routeFactory, AmodeusInteractionFinder interactionFinder,
             WaitingTime waitingTime, PopulationFactory populationFactory,
-            RoutingModule walkRoutingModule, boolean useAccessEgress, boolean predictRoute,
+            RoutingModule walkRoutingModule, boolean useAccessEgress,
             LeastCostPathCalculator router, PriceModel priceCalculator, Network network,
             TravelTime travelTime, String mode) {
         this.routeFactory = routeFactory;
@@ -53,7 +52,6 @@ public class AmodeusRoutingModule implements RoutingModule {
         this.walkRoutingModule = walkRoutingModule;
         this.populationFactory = populationFactory;
         this.useAccessEgress = useAccessEgress;
-        this.predictRoute = predictRoute;
         this.router = router;
         this.priceCalculator = priceCalculator;
         this.mode = mode;
@@ -123,19 +121,18 @@ public class AmodeusRoutingModule implements RoutingModule {
         double vehicleTravelTime = Double.NaN;
         Optional<Double> price = Optional.empty();
 
-        if (predictRoute) {
-            Link pickupLink = network.getLinks().get(pickupFacility.getLinkId());
-            Link dropoffLink = network.getLinks().get(dropoffFacility.getLinkId());
+        // predict route - we must always do this otherwise time tracking breaks
+        Link pickupLink = network.getLinks().get(pickupFacility.getLinkId());
+        Link dropoffLink = network.getLinks().get(dropoffFacility.getLinkId());
 
-            VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(pickupLink, dropoffLink, vehicleDepartureTime,
-                    router, travelTime);
+        VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(pickupLink, dropoffLink, vehicleDepartureTime,
+                router, travelTime);
 
-            vehicleDistance = VrpPaths.calcDistance(path);
-            vehicleTravelTime = path.getTravelTime();
+        vehicleDistance = VrpPaths.calcDistance(path);
+        vehicleTravelTime = path.getTravelTime();
 
-            price = priceCalculator.calculatePrice(requestSendTime, pickupFacility, dropoffFacility, vehicleDistance,
-                    vehicleTravelTime);
-        }
+        price = priceCalculator.calculatePrice(requestSendTime, pickupFacility, dropoffFacility, vehicleDistance,
+                vehicleTravelTime);
 
         double totalTravelTime = vehicleTravelTime + vehicleWaitingTime;
 

--- a/src/main/java/org/matsim/amodeus/routing/AmodeusRoutingModule.java
+++ b/src/main/java/org/matsim/amodeus/routing/AmodeusRoutingModule.java
@@ -89,8 +89,9 @@ public class AmodeusRoutingModule implements RoutingModule {
         List<PlanElement> routeElements = new LinkedList<>();
 
         if (fromFacility != pickupFacility && useAccessEgress && pickupEuclideanDistance > 0.0) {
-            RoutingRequest newRequest = DefaultRoutingRequest.of(fromFacility, pickupFacility, accessDepartureTime,
-                    person, routingRequest.getAttributes());
+            RoutingRequest newRequest = DefaultRoutingRequest.withoutAttributes(fromFacility, pickupFacility,
+                    accessDepartureTime,
+                    person);
             List<? extends PlanElement> pickupElements = walkRoutingModule.calcRoute(newRequest);
             routeElements.addAll(pickupElements);
 
@@ -177,8 +178,9 @@ public class AmodeusRoutingModule implements RoutingModule {
             dropoffActivity.setMaximumDuration(0.0);
             routeElements.add(dropoffActivity);
 
-            RoutingRequest newRequest = DefaultRoutingRequest.of(dropoffFacility, toFacility, egressDepartureTime,
-                    person, routingRequest.getAttributes());
+            RoutingRequest newRequest = DefaultRoutingRequest.withoutAttributes(dropoffFacility, toFacility,
+                    egressDepartureTime,
+                    person);
             List<? extends PlanElement> dropoffElements = walkRoutingModule.calcRoute(newRequest);
             routeElements.addAll(dropoffElements);
         }

--- a/src/main/java/org/matsim/amodeus/waiting_time/WaitingTimeEstimationModule.java
+++ b/src/main/java/org/matsim/amodeus/waiting_time/WaitingTimeEstimationModule.java
@@ -4,6 +4,8 @@ import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.amodeus.config.modal.WaitingTimeConfig;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.DvrpMode;
+import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.modal.ModalProviders;
 
 import com.google.inject.Inject;
@@ -39,12 +41,12 @@ public class WaitingTimeEstimationModule extends AbstractDvrpModeModule {
                 .in(Singleton.class);
     }
 
-    private static class WaitingTimeProvider extends ModalProviders.AbstractProvider<WaitingTime> {
+    private static class WaitingTimeProvider extends ModalProviders.AbstractProvider<DvrpMode, WaitingTime> {
         @Inject
         WaitingTimeFactory factory; // TODO: Why not named factories?
 
         WaitingTimeProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override
@@ -55,9 +57,10 @@ public class WaitingTimeEstimationModule extends AbstractDvrpModeModule {
         }
     };
 
-    private static class WaitingTimeCollectorProvider extends ModalProviders.AbstractProvider<WaitingTimeCollector> {
+    private static class WaitingTimeCollectorProvider
+            extends ModalProviders.AbstractProvider<DvrpMode, WaitingTimeCollector> {
         WaitingTimeCollectorProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override
@@ -66,9 +69,10 @@ public class WaitingTimeEstimationModule extends AbstractDvrpModeModule {
         }
     };
 
-    private static class WaitingTimeListenerProvider extends ModalProviders.AbstractProvider<WaitingTimeListener> {
+    private static class WaitingTimeListenerProvider
+            extends ModalProviders.AbstractProvider<DvrpMode, WaitingTimeListener> {
         WaitingTimeListenerProvider(String mode) {
-            super(mode);
+            super(mode, DvrpModes::mode);
         }
 
         @Override

--- a/src/main/java/org/matsim/amodeus/waiting_time/WaitingTimeEstimationModule.java
+++ b/src/main/java/org/matsim/amodeus/waiting_time/WaitingTimeEstimationModule.java
@@ -4,9 +4,10 @@ import org.matsim.amodeus.config.AmodeusModeConfig;
 import org.matsim.amodeus.config.modal.WaitingTimeConfig;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
-import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.modal.ModalProviders;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
 public class WaitingTimeEstimationModule extends AbstractDvrpModeModule {
@@ -22,14 +23,20 @@ public class WaitingTimeEstimationModule extends AbstractDvrpModeModule {
         WaitingTimeConfig waitingTimeConfig = modeConfig.getWaitingTimeEstimationConfig();
 
         if (waitingTimeConfig.getEstimationAlpha() > 0.0) {
-            bindModal(WaitingTimeCollector.class).toProvider(new WaitingTimeCollectorProvider(getMode())).in(Singleton.class);
-            bindModal(WaitingTimeListener.class).toProvider(new WaitingTimeListenerProvider(getMode())).in(Singleton.class);
+            bindModal(WaitingTimeCollector.class)
+                    .toProvider((Provider<? extends WaitingTimeCollector>) new WaitingTimeCollectorProvider(getMode()))
+                    .in(Singleton.class);
+            bindModal(WaitingTimeListener.class)
+                    .toProvider((Provider<? extends WaitingTimeListener>) new WaitingTimeListenerProvider(getMode()))
+                    .in(Singleton.class);
 
             addEventHandlerBinding().to(modalKey(WaitingTimeListener.class));
             addControlerListenerBinding().to(modalKey(WaitingTimeListener.class));
         }
 
-        bindModal(WaitingTime.class).toProvider(new WaitingTimeProvider(getMode())).in(Singleton.class);
+        bindModal(WaitingTime.class)
+                .toProvider((Provider<? extends WaitingTime>) new WaitingTimeProvider(getMode()))
+                .in(Singleton.class);
     }
 
     private static class WaitingTimeProvider extends ModalProviders.AbstractProvider<WaitingTime> {

--- a/src/test/java/amodeus/amodeus/analysis/element/OccupancyDistanceRatiosImageTest.java
+++ b/src/test/java/amodeus/amodeus/analysis/element/OccupancyDistanceRatiosImageTest.java
@@ -3,6 +3,7 @@ package amodeus.amodeus.analysis.element;
 
 import java.io.File;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import amodeus.amodeus.analysis.plot.ColorDataAmodeusSpecific;
@@ -14,6 +15,7 @@ import ch.ethz.idsc.tensor.img.ColorDataIndexed;
 
 public class OccupancyDistanceRatiosImageTest {
     @Test
+    @Ignore // won't work due to funky vscode SSH X11 forwarding
     public void test() {
         OccupancyDistanceRatiosImage image = OccupancyDistanceRatiosImage.INSTANCE;
         File dir = MultiFileTools.getDefaultWorkingDirectory();

--- a/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -3,6 +3,7 @@ package amodeus.amodeus.matsim;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -292,7 +293,7 @@ public class StandardMATSimScenarioTest {
                         .toProvider((Provider<? extends VirtualNetwork<Link>>) ModalProviders
                                 .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
                                     Network network = getter.getModal(Network.class);
-                                    return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
+                                    return (Annotation) MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
                                             scenario.getPopulation(),
                                             network, 2, true);
                                 }, null));
@@ -313,7 +314,8 @@ public class StandardMATSimScenarioTest {
                                         Network network = getter.getModal(Network.class);
                                         Population population = getter.get(Population.class);
 
-                                        return StaticTravelDataCreator.create(simOptions.getWorkingDirectory(),
+                                        return (Annotation) StaticTravelDataCreator.create(
+                                                simOptions.getWorkingDirectory(),
                                                 virtualNetwork,
                                                 network, population, simOptions.getdtTravelData(),
                                                 generatorConfig.getNumberOfVehicles(), endTime);

--- a/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -290,17 +290,18 @@ public class StandardMATSimScenarioTest {
 
                 bind(modalAnnotationCreator.key(new TypeLiteral<VirtualNetwork<Link>>() {
                 }, AmodeusModeConfig.DEFAULT_MODE))
-                        .toProvider(ModalProviders.createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
-                            Network network = getter.getModal(Network.class);
-                            return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
-                                    scenario.getPopulation(),
-                                    network, 2, true);
-                        }));
+                        .toProvider(ModalProviders.createProvider(AmodeusModeConfig.DEFAULT_MODE,
+                                modalAnnotationCreator, getter -> {
+                                    Network network = getter.getModal(Network.class);
+                                    return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
+                                            scenario.getPopulation(),
+                                            network, 2, true);
+                                }));
 
                 bind(modalAnnotationCreator.key(new TypeLiteral<TravelData>() {
                 }, AmodeusModeConfig.DEFAULT_MODE))
                         .toProvider(ModalProviders
-                                .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
+                                .createProvider(AmodeusModeConfig.DEFAULT_MODE, modalAnnotationCreator, getter -> {
                                     try {
                                         LPOptions lpOptions = new LPOptions(simOptions.getWorkingDirectory(),
                                                 LPOptionsBase.getDefault());

--- a/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -38,8 +38,10 @@ import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.modal.ModalAnnotationCreator;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
@@ -50,6 +52,7 @@ import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 
 import amodeus.amodeus.data.LocationSpec;
@@ -98,7 +101,8 @@ public class StandardMATSimScenarioTest {
                 { "NoExplicitCommunication" }, //
                 { "SBNoExplicitCommunication" }, //
 
-                // This one doesn't finish all requests. Bug or not enough of time? Also it's not good in an automated unit test because it
+                // This one doesn't finish all requests. Bug or not enough of time? Also it's
+                // not good in an automated unit test because it
                 // produces large amounts of log output.
                 { "HighCapacityDispatcher" },
 
@@ -116,7 +120,8 @@ public class StandardMATSimScenarioTest {
     }
 
     private static void makeMultimodal(Scenario scenario) {
-        // Add pt-links to the network to test a multimodal network as it appears in standard MATSim use cases
+        // Add pt-links to the network to test a multimodal network as it appears in
+        // standard MATSim use cases
 
         Network network = scenario.getNetwork();
         NetworkFactory factory = network.getFactory();
@@ -128,33 +133,42 @@ public class StandardMATSimScenarioTest {
             Id<Node> fromNodeId = Id.createNodeId(String.format("%d:%d", i, i));
             Id<Node> toNodeId = Id.createNodeId(String.format("%d:%d", i + 1, i + 1));
 
-            Link ptFowardLink = factory.createLink(ptFowardLinkId, network.getNodes().get(fromNodeId), network.getNodes().get(toNodeId));
+            Link ptFowardLink = factory.createLink(ptFowardLinkId, network.getNodes().get(fromNodeId),
+                    network.getNodes().get(toNodeId));
             ptFowardLink.setFreespeed(100.0 * 1000.0 / 3600.0);
             ptFowardLink.setLength(1000.0);
             ptFowardLink.setAllowedModes(Collections.singleton("pt"));
             network.addLink(ptFowardLink);
 
-            Link ptBackwardLink = factory.createLink(ptBackwardLinkId, network.getNodes().get(toNodeId), network.getNodes().get(fromNodeId));
+            Link ptBackwardLink = factory.createLink(ptBackwardLinkId, network.getNodes().get(toNodeId),
+                    network.getNodes().get(fromNodeId));
             ptBackwardLink.setFreespeed(100.0 * 1000.0 / 3600.0);
             ptBackwardLink.setLength(1000.0);
             ptBackwardLink.setAllowedModes(Collections.singleton("pt"));
             network.addLink(ptBackwardLink);
         }
 
-        // Also, a routed population may have "pt interaction" activities, which take place at links that are not part of the road network. Amodeus must be able
+        // Also, a routed population may have "pt interaction" activities, which take
+        // place at links that are not part of the road network. Amodeus must be able
         // to
         // handle these cases.
 
-        /* for (Person person : scenario.getPopulation().getPersons().values())
+        /*
+         * for (Person person : scenario.getPopulation().getPersons().values())
          * for (Plan plan : person.getPlans()) {
-         * Activity trickyActivity = PopulationUtils.createActivityFromCoordAndLinkId("pt interaction", new Coord(5500.0, 5500.0), Id.createLinkId("pt_fwd_5:5"));
+         * Activity trickyActivity =
+         * PopulationUtils.createActivityFromCoordAndLinkId("pt interaction", new
+         * Coord(5500.0, 5500.0), Id.createLinkId("pt_fwd_5:5"));
          * 
          * plan.getPlanElements().add(PopulationUtils.createLeg("walk"));
          * plan.getPlanElements().add(trickyActivity);
-         * } */
+         * }
+         */
 
-        // TODO @sebhoerl Difficult to keep this in as handling of "interaction" activities become much smarter in MATSim now. We would need to
-        // set up a much more realistic test scenario. There is one in the AV package, so we can use that one!
+        // TODO @sebhoerl Difficult to keep this in as handling of "interaction"
+        // activities become much smarter in MATSim now. We would need to
+        // set up a much more realistic test scenario. There is one in the AV package,
+        // so we can use that one!
 
         for (Link link : network.getLinks().values()) {
             if (link.getAllowedModes().contains("car")) {
@@ -164,7 +178,8 @@ public class StandardMATSimScenarioTest {
     }
 
     private static void fixInvalidActivityLocations(Network network, Population population) {
-        // In the test fixture there are agents who start and end activities on non-car links. This should not be happen and is fixed here.
+        // In the test fixture there are agents who start and end activities on non-car
+        // links. This should not be happen and is fixed here.
 
         Network roadNetwork = NetworkUtils.createNetwork();
         new TransportModeNetworkFilter(network).filter(roadNetwork, Collections.singleton("car"));
@@ -187,16 +202,20 @@ public class StandardMATSimScenarioTest {
     @BeforeClass
     public static void setUp() throws IOException {
         // copy scenario data into main directory
-        File scenarioDirectory = new File(Locate.repoFolder(StandardMATSimScenarioTest.class, "amodeus"), "resources/testScenario");
+        File scenarioDirectory = new File(Locate.repoFolder(StandardMATSimScenarioTest.class, "amodeus"),
+                "resources/testScenario");
         File workingDirectory = MultiFileTools.getDefaultWorkingDirectory();
         GlobalAssert.that(workingDirectory.isDirectory());
-        TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), workingDirectory.getAbsolutePath());
+        TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(),
+                workingDirectory.getAbsolutePath());
     }
 
     @Test
     public void testStandardMATSimScenario() throws IOException {
-        /* This test runs a small test scenario with the different dispatchers and makes
-         * sure that all 100 generated agents arrive */
+        /*
+         * This test runs a small test scenario with the different dispatchers and makes
+         * sure that all 100 generated agents arrive
+         */
         StaticHelper.setup();
         MatsimRandom.reset();
         Id.resetCaches();
@@ -216,7 +235,8 @@ public class StandardMATSimScenarioTest {
         ReferenceFrame referenceFrame = locationSpec.referenceFrame();
         MatsimAmodeusDatabase db = MatsimAmodeusDatabase.initialize(scenario.getNetwork(), referenceFrame);
 
-        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore().getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE);
+        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore()
+                .getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE);
         modeParams.setMonetaryDistanceRate(0.0);
         modeParams.setMarginalUtilityOfTraveling(8.86);
         modeParams.setConstant(0.0);
@@ -261,34 +281,46 @@ public class StandardMATSimScenarioTest {
         // Set up a virtual network for the LPFBDispatcher
 
         controller.addOverridingModule(new AbstractModule() {
+            private final ModalAnnotationCreator<DvrpMode> modalAnnotationCreator = DvrpModes::mode;
+
             @Override
             public void install() {
                 // TODO: This is not modalized now!
 
-                bind(DvrpModes.key(new TypeLiteral<VirtualNetwork<Link>>() {
-                }, AmodeusModeConfig.DEFAULT_MODE)).toProvider(ModalProviders.createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
-                    Network network = getter.getModal(Network.class);
-                    return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(scenario.getPopulation(), network, 2, true);
-                }));
+                bind(modalAnnotationCreator.key(new TypeLiteral<VirtualNetwork<Link>>() {
+                }, AmodeusModeConfig.DEFAULT_MODE))
+                        .toProvider((Provider<? extends VirtualNetwork<Link>>) ModalProviders
+                                .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
+                                    Network network = getter.getModal(Network.class);
+                                    return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
+                                            scenario.getPopulation(),
+                                            network, 2, true);
+                                }, null));
 
-                bind(DvrpModes.key(new TypeLiteral<TravelData>() {
-                }, AmodeusModeConfig.DEFAULT_MODE)).toProvider(ModalProviders.createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
-                    try {
-                        LPOptions lpOptions = new LPOptions(simOptions.getWorkingDirectory(), LPOptionsBase.getDefault());
-                        lpOptions.setProperty(LPOptionsBase.LPSOLVER, "timeInvariant");
-                        lpOptions.saveAndOverwriteLPOptions();
+                bind(modalAnnotationCreator.key(new TypeLiteral<TravelData>() {
+                }, AmodeusModeConfig.DEFAULT_MODE))
+                        .toProvider((Provider<? extends TravelData>) ModalProviders
+                                .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
+                                    try {
+                                        LPOptions lpOptions = new LPOptions(simOptions.getWorkingDirectory(),
+                                                LPOptionsBase.getDefault());
+                                        lpOptions.setProperty(LPOptionsBase.LPSOLVER, "timeInvariant");
+                                        lpOptions.saveAndOverwriteLPOptions();
 
-                        VirtualNetwork<Link> virtualNetwork = getter.getModal(new TypeLiteral<VirtualNetwork<Link>>() {
-                        });
-                        Network network = getter.getModal(Network.class);
-                        Population population = getter.get(Population.class);
+                                        VirtualNetwork<Link> virtualNetwork = getter
+                                                .getModal(new TypeLiteral<VirtualNetwork<Link>>() {
+                                                });
+                                        Network network = getter.getModal(Network.class);
+                                        Population population = getter.get(Population.class);
 
-                        return StaticTravelDataCreator.create(simOptions.getWorkingDirectory(), virtualNetwork, network, population, simOptions.getdtTravelData(),
-                                generatorConfig.getNumberOfVehicles(), endTime);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }));
+                                        return StaticTravelDataCreator.create(simOptions.getWorkingDirectory(),
+                                                virtualNetwork,
+                                                network, population, simOptions.getdtTravelData(),
+                                                generatorConfig.getNumberOfVehicles(), endTime);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }, null));
             }
         });
 
@@ -305,14 +337,15 @@ public class StandardMATSimScenarioTest {
                     public void handleEvent(LinkEnterEvent event) {
                         // Fail if an AV attempts to enter a pt link
 
-                        if (event.getVehicleId().toString().startsWith("amodeus") && event.getLinkId().toString().startsWith("pt")) {
+                        if (event.getVehicleId().toString().startsWith("amodeus")
+                                && event.getLinkId().toString().startsWith("pt")) {
                             Assert.fail("AV attempted to enter PT link");
                         }
                     }
                 });
             }
         });
-        
+
         controller.configureQSimComponents(AmodeusQSimModule.activateModes(avConfig));
 
         controller.run();
@@ -321,14 +354,15 @@ public class StandardMATSimScenarioTest {
             System.out.println("numberOfDepartures=" + analyzer.numberOfDepartures);
             System.out.println("numberOfArrivals  =" + analyzer.numberOfArrivals);
         }
-        
+
         if (dispatcher.equals("AlonsoMoraDispatcher")) {
             // Algorithm works with rejections!
-         // Seems to be not deterministic ... probably the fault of Sets / Maps
-            
+            // Seems to be not deterministic ... probably the fault of Sets / Maps
+
             Assert.assertTrue(analyzer.numberOfArrivals > 50);
-        } else if (dispatcher.equals("HighCapacityDispatcher")) { 
-            // Seems to be not deterministic ... probably the fault of Sets / Maps, or delayed routing
+        } else if (dispatcher.equals("HighCapacityDispatcher")) {
+            // Seems to be not deterministic ... probably the fault of Sets / Maps, or
+            // delayed routing
             Assert.assertTrue(analyzer.numberOfArrivals > 50);
         } else {
             Assert.assertEquals(analyzer.numberOfDepartures, analyzer.numberOfArrivals);

--- a/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
+++ b/src/test/java/amodeus/amodeus/matsim/StandardMATSimScenarioTest.java
@@ -290,17 +290,16 @@ public class StandardMATSimScenarioTest {
 
                 bind(modalAnnotationCreator.key(new TypeLiteral<VirtualNetwork<Link>>() {
                 }, AmodeusModeConfig.DEFAULT_MODE))
-                        .toProvider((Provider<? extends VirtualNetwork<Link>>) ModalProviders
-                                .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
-                                    Network network = getter.getModal(Network.class);
-                                    return (Annotation) MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
-                                            scenario.getPopulation(),
-                                            network, 2, true);
-                                }, null));
+                        .toProvider(ModalProviders.createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
+                            Network network = getter.getModal(Network.class);
+                            return MatsimKMeansVirtualNetworkCreator.createVirtualNetwork(
+                                    scenario.getPopulation(),
+                                    network, 2, true);
+                        }));
 
                 bind(modalAnnotationCreator.key(new TypeLiteral<TravelData>() {
                 }, AmodeusModeConfig.DEFAULT_MODE))
-                        .toProvider((Provider<? extends TravelData>) ModalProviders
+                        .toProvider(ModalProviders
                                 .createProvider(AmodeusModeConfig.DEFAULT_MODE, getter -> {
                                     try {
                                         LPOptions lpOptions = new LPOptions(simOptions.getWorkingDirectory(),
@@ -314,7 +313,7 @@ public class StandardMATSimScenarioTest {
                                         Network network = getter.getModal(Network.class);
                                         Population population = getter.get(Population.class);
 
-                                        return (Annotation) StaticTravelDataCreator.create(
+                                        return StaticTravelDataCreator.create(
                                                 simOptions.getWorkingDirectory(),
                                                 virtualNetwork,
                                                 network, population, simOptions.getdtTravelData(),
@@ -322,7 +321,7 @@ public class StandardMATSimScenarioTest {
                                     } catch (Exception e) {
                                         throw new RuntimeException(e);
                                     }
-                                }, null));
+                                }));
             }
         });
 

--- a/src/test/java/amodeus/amodeus/test/ScenarioExecutionTest.java
+++ b/src/test/java/amodeus/amodeus/test/ScenarioExecutionTest.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.matsim.api.core.v01.network.Network;
@@ -64,7 +65,8 @@ public class ScenarioExecutionTest {
         TestFileHandling.copyScnearioToMainDirectory(scenarioDirectory.getAbsolutePath(), //
                 workingDirectory.getAbsolutePath());
 
-        // copy LPOptions from other location to ensure no travel data object is created,
+        // copy LPOptions from other location to ensure no travel data object is
+        // created,
         // the dispatcher used in this test does not require it.
         File helperDirectory = //
                 new File(Locate.repoFolder(ScenarioExecutionTest.class, "amodeus"), "resources/helperFiles");
@@ -115,9 +117,12 @@ public class ScenarioExecutionTest {
         File workingDirectory = MultiFileTools.getDefaultWorkingDirectory();
         ScenarioOptions scenarioOptions = new ScenarioOptions(workingDirectory, ScenarioOptionsBase.getDefault());
 
-        assertEquals(new File(workingDirectory, "config.xml").getAbsolutePath(), scenarioOptions.getSimulationConfigName());
-        assertEquals(new File(workingDirectory, "preparedNetwork").getAbsolutePath(), scenarioOptions.getPreparedNetworkName());
-        assertEquals(new File(workingDirectory, "preparedPopulation").getAbsolutePath(), scenarioOptions.getPreparedPopulationName());
+        assertEquals(new File(workingDirectory, "config.xml").getAbsolutePath(),
+                scenarioOptions.getSimulationConfigName());
+        assertEquals(new File(workingDirectory, "preparedNetwork").getAbsolutePath(),
+                scenarioOptions.getPreparedNetworkName());
+        assertEquals(new File(workingDirectory, "preparedPopulation").getAbsolutePath(),
+                scenarioOptions.getPreparedPopulationName());
 
         // simulation objects should exist after simulation (simulation data)
         File simobj = new File("output/001/simobj/it.00");
@@ -133,7 +138,10 @@ public class ScenarioExecutionTest {
 
         AnalysisTestExport ate = testServer.getAnalysisTestExport();
 
-        /** number of processed requests, 25 are same link requests and therefore are not covered by Amodeus */
+        /**
+         * number of processed requests, 25 are same link requests and therefore are not
+         * covered by Amodeus
+         */
         assertEquals(247, ate.getSimulationInformationElement().reqsize());
 
         /** fleet size */
@@ -157,11 +165,16 @@ public class ScenarioExecutionTest {
         assertTrue(Scalars.lessEquals(ZERO_KM, (Scalar) s)));
         assertEquals(Total.of(ate.getDistancElement().totalDistancesPerVehicle), ate.getDistancElement().totalDistance);
 
-        scalarAssert.add((Scalar) Quantity.of(2826.02084, "km").map(Round._5), (Scalar) ate.getDistancElement().totalDistance.map(Round._5));
-        scalarAssert.add((Scalar) Quantity.of(1043.56479, "km").map(Round._5), (Scalar) ate.getDistancElement().totalDistanceWtCst.map(Round._5));
-        scalarAssert.add((Scalar) Quantity.of(269.22377, "km").map(Round._5), (Scalar) ate.getDistancElement().totalDistancePicku.map(Round._5));
-        scalarAssert.add((Scalar) Quantity.of(1513.23228, "km").map(Round._5), (Scalar) ate.getDistancElement().totalDistanceRebal.map(Round._5));
-        scalarAssert.add((Scalar) RealScalar.of(0.36927).map(Round._5), (Scalar) ate.getDistancElement().totalDistanceRatio.map(Round._5));
+        scalarAssert.add((Scalar) Quantity.of(2826.02084, "km").map(Round._5),
+                (Scalar) ate.getDistancElement().totalDistance.map(Round._5));
+        scalarAssert.add((Scalar) Quantity.of(1043.56479, "km").map(Round._5),
+                (Scalar) ate.getDistancElement().totalDistanceWtCst.map(Round._5));
+        scalarAssert.add((Scalar) Quantity.of(269.22377, "km").map(Round._5),
+                (Scalar) ate.getDistancElement().totalDistancePicku.map(Round._5));
+        scalarAssert.add((Scalar) Quantity.of(1513.23228, "km").map(Round._5),
+                (Scalar) ate.getDistancElement().totalDistanceRebal.map(Round._5));
+        scalarAssert.add((Scalar) RealScalar.of(0.36927).map(Round._5),
+                (Scalar) ate.getDistancElement().totalDistanceRatio.map(Round._5));
 
         scalarAssert.add((Scalar) Total.of(ate.getDistancElement().totalDistancesPerVehicle), //
                 ate.getDistancElement().totalDistance);
@@ -178,24 +191,32 @@ public class ScenarioExecutionTest {
             Scalars.lessEquals((Quantity) t, ate.getTravelTimeAnalysis().getWaitAggrgte().Get(2));
         });
 
-        assertTrue(Scalars.lessEquals(Quantity.of(0, SI.SECOND), ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(0)));
+        assertTrue(Scalars.lessEquals(Quantity.of(0, SI.SECOND),
+                ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(0)));
         assertTrue(Scalars.lessEquals(ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(0), //
                 ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(1)));
         assertTrue(Scalars.lessEquals(ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(1), //
                 ate.getTravelTimeAnalysis().getWaitAggrgte().get(0).Get(2)));
         assertTrue(Scalars.lessEquals(Quantity.of(0, SI.SECOND), ate.getTravelTimeAnalysis().getWaitAggrgte().Get(1)));
 
-        scalarAssert.add(Quantity.of(389.2105263157895, SI.SECOND), ate.getTravelTimeAnalysis().getWaitAggrgte().Get(1));
+        scalarAssert.add(Quantity.of(389.2105263157895, SI.SECOND),
+                ate.getTravelTimeAnalysis().getWaitAggrgte().Get(1));
         scalarAssert.add(Quantity.of(2397.0, SI.SECOND), ate.getTravelTimeAnalysis().getWaitAggrgte().Get(2));
-        scalarAssert.add(Quantity.of(RationalScalar.of(221400, 247), SI.SECOND), ate.getTravelTimeAnalysis().getDrveAggrgte().Get(1));
+        scalarAssert.add(Quantity.of(RationalScalar.of(221400, 247), SI.SECOND),
+                ate.getTravelTimeAnalysis().getDrveAggrgte().Get(1));
         scalarAssert.add(Quantity.of(3480, SI.SECOND), ate.getTravelTimeAnalysis().getDrveAggrgte().Get(2));
 
-        /* TODO @sebhoerl Have a look at {AmodeusModule::install}. At some point the travel time
+        /*
+         * TODO @sebhoerl Have a look at {AmodeusModule::install}. At some point the
+         * travel time
          * calculation in DVRP has been improved.
          * Unfortunately, this improvement breaks these tests.
-         * The reference numbers here should be adjusted at some point so that the fallback in
+         * The reference numbers here should be adjusted at some point so that the
+         * fallback in
          * {AmodeusModule::install} can be removed again.
-         * (Nevertheless, we're talking about a different in routed time of +/-1 second). /sebhoerl */
+         * (Nevertheless, we're talking about a different in routed time of +/-1
+         * second). /sebhoerl
+         */
         scalarAssert.consolidate();
 
         /** presence of plot files */
@@ -229,6 +250,7 @@ public class ScenarioExecutionTest {
     }
 
     @Test
+    @Ignore // unable to run in headless mode successfully
     public void testD_Viewer() throws IOException {
         if (!UserName.is("travis")) {
             // run scenario viewer

--- a/src/test/java/org/matsim/amodeus/RunTest.java
+++ b/src/test/java/org/matsim/amodeus/RunTest.java
@@ -49,7 +49,8 @@ public class RunTest {
 
         config.controler().setWriteEventsInterval(1);
 
-        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore().getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // TODO: Refactor
+        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore()
+                .getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // TODO: Refactor
         modeParams.setMonetaryDistanceRate(0.0);
         modeParams.setMarginalUtilityOfTraveling(8.86);
         modeParams.setConstant(0.0);
@@ -122,7 +123,8 @@ public class RunTest {
         Config config = ConfigUtils.createConfig(avConfigGroup, new DvrpConfigGroup());
         Scenario scenario = TestScenarioGenerator.generateWithAVLegs(config);
 
-        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore().getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
+        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore()
+                .getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
         modeParams.setMonetaryDistanceRate(0.0);
         modeParams.setMarginalUtilityOfTraveling(8.86);
         modeParams.setConstant(0.0);
@@ -176,7 +178,8 @@ public class RunTest {
         activityParams.setTypicalDuration(1.0);
         config.planCalcScore().addActivityParams(activityParams);
 
-        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore().getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
+        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore()
+                .getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
         modeParams.setMonetaryDistanceRate(0.0);
         modeParams.setMarginalUtilityOfTraveling(8.86);
         modeParams.setConstant(0.0);
@@ -227,7 +230,8 @@ public class RunTest {
         activityParams.setTypicalDuration(1.0);
         config.planCalcScore().addActivityParams(activityParams);
 
-        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore().getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
+        PlanCalcScoreConfigGroup.ModeParams modeParams = config.planCalcScore()
+                .getOrCreateModeParams(AmodeusModeConfig.DEFAULT_MODE); // Refactor av
         modeParams.setMonetaryDistanceRate(0.0);
         modeParams.setMarginalUtilityOfTraveling(8.86);
         modeParams.setConstant(0.0);
@@ -279,7 +283,8 @@ public class RunTest {
         controller.addOverridingModule(new AmodeusModule());
 
         controller.addOverridingQSimModule(new AmodeusQSimModule());
-        controller.configureQSimComponents(AmodeusQSimModule.activateModes(AmodeusConfigGroup.get(controller.getConfig())));
+        controller.configureQSimComponents(
+                AmodeusQSimModule.activateModes(AmodeusConfigGroup.get(controller.getConfig())));
 
         // Some analysis listener for testing
         TestScenarioAnalyzer analyzer = new TestScenarioAnalyzer();

--- a/src/test/java/org/matsim/amodeus/drt/RunDrtTest.java
+++ b/src/test/java/org/matsim/amodeus/drt/RunDrtTest.java
@@ -20,7 +20,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.extensive.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -64,11 +64,13 @@ public class RunDrtTest {
 
     @Test
     public void testAmodeusDrt() {
-        Config config = ConfigUtils.createConfig(new MultiModeDrtConfigGroup(), new DvrpConfigGroup(), new AmodeusConfigGroup());
+        Config config = ConfigUtils.createConfig(new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
+                new AmodeusConfigGroup());
         Scenario scenario = TestScenarioGenerator.generateWithAVLegs(config);
         run(config, scenario, true);
 
-        // Currently, Amodeus does not know where to put the auto-generated ScenarioOptions file.
+        // Currently, Amodeus does not know where to put the auto-generated
+        // ScenarioOptions file.
         // We can make this a config option for AmodeusConfigGroup.
         FileUtils.deleteQuietly(new File("AmodeusOptions.properties"));
     }
@@ -115,7 +117,8 @@ public class RunDrtTest {
         dvrpConfig.setTravelTimeEstimationBeta(900);
 
         // SCENARIO PART
-        scenario.getPopulation().getFactory().getRouteFactories().setRouteFactory(DrtRoute.class, new DrtRouteFactory());
+        scenario.getPopulation().getFactory().getRouteFactories().setRouteFactory(DrtRoute.class,
+                new DrtRouteFactory());
 
         // CONTROLLER PART
         Controler controller = new Controler(scenario);
@@ -128,13 +131,17 @@ public class RunDrtTest {
         // Here we start overriding things of DRT with Amodeus
         if (useAmodeus) {
 
-            // This is a per-mode config, which usually is contained in a AmodeusConfigGroup,
-            // here we only use it to set up a small portion of Amodeus (the dispatching part),
+            // This is a per-mode config, which usually is contained in a
+            // AmodeusConfigGroup,
+            // here we only use it to set up a small portion of Amodeus (the dispatching
+            // part),
             // and not scoring, waiting times, etc.
             AmodeusModeConfig amodeusModeConfig = new AmodeusModeConfig(drtModeConfig.getMode());
 
-            // We can choose the dispatcher and set additional options. Note that some dispatchers
-            // rely heavily on GLPK. You need to install it and then tell JAVA where to find it
+            // We can choose the dispatcher and set additional options. Note that some
+            // dispatchers
+            // rely heavily on GLPK. You need to install it and then tell JAVA where to find
+            // it
             // via -Djava.library.path=/path/to/glpk/lib/jni on the command line.
             amodeusModeConfig.getDispatcherConfig().setType("FeedforwardFluidicRebalancingPolicy");
 
@@ -144,19 +151,24 @@ public class RunDrtTest {
             // Disable Amodeus-specific output (e.g., for the viewer)
             amodeusModeConfig.getDispatcherConfig().setPublishPeriod(0);
 
-            // Path where to generate or read a VirtualNetwork and TravelData for rebalancing.
+            // Path where to generate or read a VirtualNetwork and TravelData for
+            // rebalancing.
             // Note that not all dispatchers need this.
-            amodeusModeConfig.getDispatcherConfig().setVirtualNetworkPath(new File("test_data/virtualNetwork").getAbsolutePath());
-            amodeusModeConfig.getDispatcherConfig().setTravelDataPath(new File("test_data/travelData").getAbsolutePath());
+            amodeusModeConfig.getDispatcherConfig()
+                    .setVirtualNetworkPath(new File("test_data/virtualNetwork").getAbsolutePath());
+            amodeusModeConfig.getDispatcherConfig()
+                    .setTravelDataPath(new File("test_data/travelData").getAbsolutePath());
 
             // Add a subset of Amodeus modules which usually would be added automatically
             // in the upper-level AmodeusModule.
             controller.addOverridingModule(new VirtualNetworkModeModule(amodeusModeConfig));
             controller.addOverridingModule(new AmodeusModule());
 
-            // Add overriding modules for the Drt <-> Amodeus integration, which override some
+            // Add overriding modules for the Drt <-> Amodeus integration, which override
+            // some
             // components of DRT. Later on, we would only override DrtOptimizer, but we are
-            // not there yet, because Amodeus internally still works with AmodeusStayTask, etc.
+            // not there yet, because Amodeus internally still works with AmodeusStayTask,
+            // etc.
             // and does not understand DrtStayTask, etc.
             controller.addOverridingModule(new AmodeusDrtModule());
             AmodeusDrtModule.overrideDispatchers(controller, config);
@@ -168,7 +180,8 @@ public class RunDrtTest {
     static public void createFleet(String path, int numberOfVehicles, Network network) {
         Random random = new Random(0);
 
-        List<Link> links = network.getLinks().values().stream().filter(link -> link.getAllowedModes().contains("car")).collect(Collectors.toList());
+        List<Link> links = network.getLinks().values().stream().filter(link -> link.getAllowedModes().contains("car"))
+                .collect(Collectors.toList());
 
         new FleetWriter(IntStream.range(0, 100).mapToObj(i -> {
             return ImmutableDvrpVehicleSpecification.newBuilder() //

--- a/src/test/java/org/matsim/amodeus/dynamics/TestScenario.java
+++ b/src/test/java/org/matsim/amodeus/dynamics/TestScenario.java
@@ -33,7 +33,7 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
-import org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;
+import org.matsim.core.modal.ModalProviders.InstanceGetter;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -52,7 +52,10 @@ import org.matsim.vehicles.VehicleUtils;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 
-/** TestScenario is used to create a various elements of a test scenario. This is used in various av.dynamics tests. */
+/**
+ * TestScenario is used to create a various elements of a test scenario. This is
+ * used in various av.dynamics tests.
+ */
 public class TestScenario {
 
     static public Scenario createScenario(AmodeusConfigGroup avConfig, Collection<TestRequest> requests) {
@@ -193,7 +196,7 @@ public class TestScenario {
 
         @Override
         public AmodeusGenerator createGenerator(InstanceGetter inject) {
-            Link link = inject.getModal(Network.class).getLinks().get(linkId);
+            Link link = ((Network) inject.getModal(Network.class)).getLinks().get(linkId);
             return new SingleVehicleGenerator(link, capacity);
         }
     }
@@ -251,7 +254,8 @@ public class TestScenario {
 
         @Override
         public void handleEvent(PersonArrivalEvent event) {
-            if (!event.getPersonId().toString().equals("vehicle") && event.getLegMode().equals(AmodeusModeConfig.DEFAULT_MODE))
+            if (!event.getPersonId().toString().equals("vehicle")
+                    && event.getLegMode().equals(AmodeusModeConfig.DEFAULT_MODE))
                 times.add(event.getTime());
         }
     }

--- a/src/test/java/org/matsim/amodeus/scenario/TestScenarioAnalyzer.java
+++ b/src/test/java/org/matsim/amodeus/scenario/TestScenarioAnalyzer.java
@@ -10,7 +10,8 @@ import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.core.controler.AbstractModule;
 
-public class TestScenarioAnalyzer extends AbstractModule implements PersonDepartureEventHandler, PersonArrivalEventHandler, ActivityStartEventHandler {
+public class TestScenarioAnalyzer extends AbstractModule
+        implements PersonDepartureEventHandler, PersonArrivalEventHandler, ActivityStartEventHandler {
     public long numberOfDepartures;
     public long numberOfArrivals;
     public long numberOfInteractionActivities;


### PR DESCRIPTION
Update to get Amodeus working with MATSim v14. 

Summary of changes - 
- bump MATSim to v14.0 and update repo locations
- Change import location for `org.matsim.contrib.dvrp.run.ModalProviders.InstanceGetter;` to `org.matsim.core.modal.ModalProviders.InstanceGetter`
- cast InstanceGetter.get() calls to the desired class
- update DVRP mode annotation as per `org.matsim.contrib.dvrp.run.DvrpModes` updates
- bind VehicleType to DefaultVehicleType() (required to due to VehicleType changes)
- adjusted for updated calcRoute method
- removed predict route bool. Because of new time tracking we must always compute route times for each leg.
- dependency cleanup
- minor formatting improvements
